### PR TITLE
Fix incorrect release-repo branch name in main branch config

### DIFF
--- a/config/process-snapshot-pr-config-vars
+++ b/config/process-snapshot-pr-config-vars
@@ -1,6 +1,6 @@
 # Common tools repo and the branch we clone:
 tools_repo=stolostron/release   # Assumed to be on GitHub.
-tools_repo_branch=main
+tools_repo_branch=master
 
 # Spot were we clone tools. (clone spot should NOT be under work_dir)
 tools_repo_clone_dir="./release-tools"


### PR DESCRIPTION
The release repo branch name is wrong in the `process-snapshot-pr-config-vars` file added by PR #1, the correct branch is `master` not `main`.