### PR TITLE
Put a template rather than a real manifest-gen-config.json in the template branch

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -1,70 +1,19 @@
 {
     "product-images": {
-        "image-registry":  "registry.redhat.io",
-        "image-namespace": "rhacm2",
+        "image-registry":   "registry.redhat.io",
+        "image-namespace":  "rhacm2",
         "konflux-component-and-image-suffix": "acm-999",
 
         "image-list": [
-            {"image-key": "cluster_permission",                          "konflux-component-name": "cluster-permission"},
-            {"image-key": "governance_policy_addon_controller",          "konflux-component-name": "governance-policy-addon-controller"},
-            {"image-key": "governance_policy_framework_addon",           "konflux-component-name": "governance-policy-framework-addon"},
-            {"image-key": "multicluster_observability_addon",            "konflux-component-name": "ACM_MULTICLUSTER_OBSERVABILITY_ADDON"},
-            {"image-key": "acm_must_gather",                             "konflux-component-name": "must-gather"},
-            {"image-key": "search_indexer",                              "konflux-component-name": "search-indexer"},
-            {"image-key": "search_v2_api",                               "konflux-component-name": "search-v2-api"},
-            {"image-key": "search_v2_operator",                          "konflux-component-name": "search-v2-operator"},
-            {"image-key": "siteconfig_operator",                         "konflux-component-name": "siteconfig"},
-            {"image-key": "volsync_addon_controller",                    "konflux-component-name": "volsync-addon-controller"},
-            {"image-key": "cert_policy_controller",                      "konflux-component-name": "cert-policy-controller"},
-            {"image-key": "cluster_backup_controller",                   "konflux-component-name": "cluster-backup-controller"},
-            {"image-key": "config_policy_controller",                    "konflux-component-name": "config-policy-controller"},
-            {"image-key": "console",                                     "konflux-component-name": "console"},
-            {"image-key": "endpoint_monitoring_operator",                "konflux-component-name": "endpoint-monitoring-operator"},
-            {"image-key": "governance_policy_propagator",                "konflux-component-name": "governance-policy-propagator"},
-            {"image-key": "grafana",                                     "konflux-component-name": "grafana"},
-            {"image-key": "grafana_dashboard_loader",                    "konflux-component-name": "grafana-dashboard-loader"},
-            {"image-key": "insights_client",                             "konflux-component-name": "insights-client"},
-            {"image-key": "insights_metrics",                            "konflux-component-name": "insights-metrics"},
-            {"image-key": "klusterlet_addon_controller",                 "konflux-component-name": "klusterlet-addon-controller"},
-            {"image-key": "kube_rbac_proxy",                             "konflux-component-name": "kube-rbac-proxy"},
-            {"image-key": "kube_state_metrics",                          "konflux-component-name": "kube-state-metrics"},
-            {"image-key": "memcached",                                   "konflux-component-name": "MEMCACHED"},
-            {"image-key": "memcached_exporter",                          "konflux-component-name": "MEMCACHED_EXPORTER"},
-            {"image-key": "metrics_collector",                           "konflux-component-name": "metrics-collector"},
-            {"image-key": "multicloud_integrations",                     "konflux-component-name": "multicloud-integrations"},
-            {"image-key": "multicluster_observability_operator",         "konflux-component-name": "multicluster-observability-operator"},
-            {"image-key": "multicluster_operators_application",          "konflux-component-name": "multicluster-operators-application"},
-            {"image-key": "multicluster_operators_channel",              "konflux-component-name": "multicluster-operators-channel"},
-            {"image-key": "multicluster_operators_subscription",         "konflux-component-name": "multicluster-operators-subscription"},
-            {"image-key": "node_exporter",                               "konflux-component-name": "node-exporter"},
-            {"image-key": "observatorium",                               "konflux-component-name": "observatorium"},
-            {"image-key": "observatorium_operator",                      "konflux-component-name": "observatorium-operator"},
-            {"image-key": "prometheus",                                  "konflux-component-name": "prometheus"},
-            {"image-key": "prometheus_alertmanager",                     "konflux-component-name": "prometheus-alertmanager"},
-            {"image-key": "prometheus_config_reloader",                  "konflux-component-name": "prometheus-config-reloader"},
-            {"image-key": "prometheus_operator",                         "konflux-component-name": "prometheus-operator"},
-            {"image-key": "rbac_query_proxy",                            "konflux-component-name": "rbac-query-proxy"},
-            {"image-key": "search_collector",                            "konflux-component-name": "search-collector"},
-            {"image-key": "submariner_addon",                            "konflux-component-name": "submariner-addon"},
-            {"image-key": "thanos",                                      "konflux-component-name": "thanos"},
-            {"image-key": "thanos_receive_controller",                   "konflux-component-name": "thanos-receive-controller"},            
-            {"image-key": "multiclusterhub_operator",                    "konflux-component-name": "multiclusterhub-operator"}
+            {"image-key": "some_acm_image",   "konflux-component-name": "corresponding_konflix_component"}
         ]
     },
 
     "external-images": {
-        "image-list": [ { 
-              "image-key": "oauth_proxy_415_and_below",
-              "image-ref": "registry.redhat.io/openshif4/golang-github-openshift-oauth-proxy-container:XXXXXXX"
-            },{ 
-              "image-key": "oauth_proxy_416_and_up",
-              "image-ref": "registry.redhat.io/openshif4/golang-github-openshift-oauth-proxy-container:XXXXXXX"
-            },{
-              "image-key": "configmap_reloader",
-              "image-ref": "registry.redhat.io/openshif4/configmap-reload-container:XXXXXXX"
-            },{
-              "image-key": "postgresql_13",
-              "image-ref": "registry.redhat.io/openshif4/postgresql-13-container:XXXXXXX"
+        "image-list": [
+            {
+              "image-key":  "an_external_image",
+              "image-ref":  "registry.redhat.io/openshif4/the-image-repos:tag"
             }
         ]
     }


### PR DESCRIPTION
This PR strips the acm-manifest-gen-config.json down to a template so that it is not misinterpreted as being a real/current config file.