### PR TITLE
Fix incorrect konflux-component-and-image-suffix

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -2,7 +2,7 @@
     "product-images": {
         "image-registry":  "registry.redhat.io",
         "image-namespace": "rhacm2",
-        "konflux-component-and-image-suffix": "acm-999",
+        "konflux-component-and-image-suffix": "acm-212",
 
         "image-list": [
             {"image-key": "cluster_permission",                          "konflux-component-name": "cluster-permission"},


### PR DESCRIPTION
When setting up a new release branch, the `konflux-component-and-image-suffix` property of the `config/acm-manifest-gen-config.json` config file needs to be set to the suffix applied to component and image names for that release.  I missed that change when setting up the `release-2.12` branch.  This PR fixes that and hopefully gets us a manifest/bundle with some real entries in it.