### PR TITLE
Fixed misspelled konflux.additional-tags

### DIFF
--- a/config/Dockerfile.in
+++ b/config/Dockerfile.in
@@ -15,5 +15,5 @@ LABEL com.redhat.component="acm-operator-bundle-container" \
       io.k8s.display-name="acm-operator-bundle" \
       maintainer="['acm-component-maintainers@redhat.com']" \
       description="acm-operator-bundle" \
-      konflux.additional-tags="v${BUNDLE_VERSION},shapshot-${SNAPSHOT_NAME}"
+      konflux.additional-tags="v${BUNDLE_VERSION},snapshot-${SNAPSHOT_NAME}"
 


### PR DESCRIPTION
Updated the konflux.additional-tags for `shapshot` to `snapshot`.