### PR TITLE
The konflux name for the backup image is different

### DIFF
--- a/extras/2.14.0.json
+++ b/extras/2.14.0.json
@@ -20,7 +20,7 @@
   {
     "image-key": "cluster_backup_controller",
     "image-remote": "registry.redhat.io/rhacm2",
-    "image-name": "cluster-backup-controller",
+    "image-name": "cluster-backup-operator",
     "image-digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
   },
   {

--- a/manifests/advanced-cluster-management.v2.14.0-2.clusterserviceversion.yaml
+++ b/manifests/advanced-cluster-management.v2.14.0-2.clusterserviceversion.yaml
@@ -2343,7 +2343,7 @@ spec:
                 - name: OPERAND_IMAGE_CERT_POLICY_CONTROLLER
                   value: registry.redhat.io/rhacm2/cert-policy-controller@sha256:285e1f88cffcb60240190eb810709d61a506b3661e71a15a69736ae78756749c
                 - name: OPERAND_IMAGE_CLUSTER_BACKUP_CONTROLLER
-                  value: registry.redhat.io/rhacm2/cluster-backup-controller@sha256:0000000000000000000000000000000000000000000000000000000000000000
+                  value: registry.redhat.io/rhacm2/cluster-backup-operator@sha256:0000000000000000000000000000000000000000000000000000000000000000
                 - name: OPERAND_IMAGE_CLUSTER_PERMISSION
                   value: registry.redhat.io/rhacm2/cluster-permission@sha256:0000000000000000000000000000000000000000000000000000000000000000
                 - name: OPERAND_IMAGE_CONFIG_POLICY_CONTROLLER
@@ -2495,7 +2495,7 @@ spec:
   - name: cert_policy_controller
     image: registry.redhat.io/rhacm2/cert-policy-controller@sha256:285e1f88cffcb60240190eb810709d61a506b3661e71a15a69736ae78756749c
   - name: cluster_backup_controller
-    image: registry.redhat.io/rhacm2/cluster-backup-controller@sha256:0000000000000000000000000000000000000000000000000000000000000000
+    image: registry.redhat.io/rhacm2/cluster-backup-operator@sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: cluster_permission
     image: registry.redhat.io/rhacm2/cluster-permission@sha256:0000000000000000000000000000000000000000000000000000000000000000
   - name: config_policy_controller


### PR DESCRIPTION
Trying out a different image name for cluster-backup-operator since it doesn't match the current image: cluster-backup-controller