### PR TITLE
Update the postgres and memcached images

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -26,9 +26,7 @@
             {"image-key": "insights_client",                             "konflux-component-name": "insights-client"},
             {"image-key": "insights_metrics",                            "konflux-component-name": "insights-metrics"},
             {"image-key": "klusterlet_addon_controller",                 "konflux-component-name": "klusterlet-addon-controller"},
-            {"image-key": "kube_rbac_proxy",                             "konflux-component-name": "kube-rbac-proxy"},
             {"image-key": "kube_state_metrics",                          "konflux-component-name": "kube-state-metrics"},
-            {"image-key": "memcached",                                   "konflux-component-name": "MEMCACHED"},
             {"image-key": "memcached_exporter",                          "konflux-component-name": "MEMCACHED_EXPORTER"},
             {"image-key": "metrics_collector",                           "konflux-component-name": "metrics-collector"},
             {"image-key": "multicloud_integrations",                     "konflux-component-name": "multicloud-integrations"},
@@ -64,8 +62,17 @@
               "image-key": "configmap_reloader",
               "image-ref": "registry.redhat.io/openshift4/ose-configmap-reloader-rhel9:v4.16.0-202411190033.p0.gdc91ddc.assembly.stream.el9"
             },{
-              "image-key": "postgresql_13",
-              "image-ref": "registry.redhat.io/rhel8/postgresql-13:1-88.1666660357"
+              "image-key": "postgresql_16",
+              "image-ref": "registry.redhat.io/rhel8/postgresql-16:1-42.1741813436"
+            },{
+              "image-key": "memcached",
+              "image-ref": "registry.redhat.io/rhel9/memcached:latest"
+            },{
+              "image-key": "ose_kube_rbac_proxy",
+              "image-ref": "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.15.0"
+            },{
+              "image-key": "volsync",
+              "image-ref": "registry.redhat.io/rhacm2/volsync-container:rhacm-2.13-rhel-9-container-candidate"
             }
         ]
     }

--- a/extras/2.14.0.json
+++ b/extras/2.14.0.json
@@ -126,10 +126,10 @@
     "image-digest": "sha256:c0dffd1d299fb954603c2a2b5853555cc6416c23151d43cf2e7de2f4022cf8b6"
   },
   {
-    "image-key": "kube_rbac_proxy",
-    "image-remote": "registry.redhat.io/rhacm2",
-    "image-name": "kube-rbac-proxy",
-    "image-digest": "sha256:35adb02919845139eb5d66cfd9e3f173825256fdb8bfaa95a6ef2ac80a09fa4f"
+    "image-key": "ose_kube_rbac_proxy",
+    "image-remote": "registry.redhat.io/openshift4",
+    "image-name": "ose-kube-rbac-proxy",
+    "image-digest": "sha256:acdede22d424f0fcea3af9b7c198c773e403ee9758f7fa51555f341a80747235"
   },
   {
     "image-key": "kube_state_metrics",
@@ -139,15 +139,15 @@
   },
   {
     "image-key": "memcached",
-    "image-remote": "registry.redhat.io/rhacm2",
-    "image-name": "MEMCACHED",
-    "image-digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    "image-remote": "registry.redhat.io/rhel9",
+    "image-name": "memcached",
+    "image-digest": "sha256:74c41ecca5905ddfc7fc59f985745745f3bdbe411eeadd751cb86297e11f91d9"
   },
   {
     "image-key": "memcached_exporter",
     "image-remote": "registry.redhat.io/rhacm2",
-    "image-name": "MEMCACHED_EXPORTER",
-    "image-digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    "image-name": "memcached-exporter",
+    "image-digest": "sha256:9bd806cbb1b9996df3ab21d991afd1eb2bbda9f949a82cca19fe6de2a8a33845"
   },
   {
     "image-key": "metrics_collector",
@@ -306,9 +306,15 @@
     "image-digest": "sha256:c67decf44185c2b536c2e4afd7adaff053157538c154722e6741e0052f4f2b26"
   },
   {
-    "image-key": "postgresql_13",
-    "image-name": "postgresql-13",
+    "image-key": "postgresql_16",
+    "image-name": "postgresql-16",
     "image-remote": "registry.redhat.io/rhel8",
-    "image-digest": "sha256:826a1a75f4186f36217b5c1f1aa270838c4b55b1021d33a4876566bfc3b8e629"
+    "image-digest": "sha256:bb294dd87be1484a0b6f31d3f7abbbdf0eff80ac3c33b77166cdb706faae3908"
+  },
+  { 
+    "image-key": "volsync",
+    "image-name": "volsync",
+    "image-remote": "registry.redhat.io/rhacm2",
+    "image-digest": "sha256:ab0e5a22a273e298802437e3b4d083c8cfc55da6c23a43d7c840b740248bf110"
   }
 ]


### PR DESCRIPTION
Memcached is an external image which is not built from one of our repositories.  Postgresql was moved to version 16 and just needed to be updated.  What else needs to be updated?