### PR TITLE
Fixing several problems in the konflux acm bundle image definitions

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -8,7 +8,7 @@
             {"image-key": "acm_cli",                                     "konflux-component-name": "acm-cli", "publish-name": "acm-cli-rhel9"},
             {"image-key": "acm_must_gather",                             "konflux-component-name": "must-gather", "publish-name": "acm-must-gather-rhel9"},
             {"image-key": "cert_policy_controller",                      "konflux-component-name": "cert-policy-controller", "publish-name": "cert-policy-controller-rhel9"},
-            {"image-key": "cluster_backup_controller",                   "konflux-component-name": "cluster-backup-controller", "publish-name": "cluster-backup-rhel9-operator"},
+            {"image-key": "cluster_backup_controller",                   "konflux-component-name": "cluster-backup-operator", "publish-name": "cluster-backup-rhel9-operator"},
             {"image-key": "cluster_permission",                          "konflux-component-name": "cluster-permission", "publish-name": "acm-cluster-permission-rhel9"},
             {"image-key": "config_policy_controller",                    "konflux-component-name": "config-policy-controller", "publish-name": "config-policy-controller-rhel9"},
             {"image-key": "console",                                     "konflux-component-name": "console", "publish-name": "console-rhel9"},
@@ -27,10 +27,10 @@
             {"image-key": "insights_metrics",                            "konflux-component-name": "insights-metrics", "publish-name": "insights-metrics-rhel9"},
             {"image-key": "klusterlet_addon_controller",                 "konflux-component-name": "klusterlet-addon-controller", "publish-name": "klusterlet-addon-controller-rhel9"},
             {"image-key": "kube_state_metrics",                          "konflux-component-name": "kube-state-metrics", "publish-name": "kube-state-metrics-rhel9"},
-            {"image-key": "memcached_exporter",                          "konflux-component-name": "MEMCACHED_EXPORTER", "publish-name": "MEMCACHED_EXPORTER-rhel9"},
+            {"image-key": "memcached_exporter",                          "konflux-component-name": "memcached-exporter", "publish-name": "MEMCACHED_EXPORTER-rhel9"},
             {"image-key": "metrics_collector",                           "konflux-component-name": "metrics-collector", "publish-name": "metrics-collector-rhel9"},
             {"image-key": "multicloud_integrations",                     "konflux-component-name": "multicloud-integrations", "publish-name": "multicloud-integrations-rhel9"},
-            {"image-key": "multicluster_observability_addon",            "konflux-component-name": "acm-multicluster-observability-addon", "publish-name": "acm-multicluster-observability-addon-rhel9"},
+            {"image-key": "multicluster_observability_addon",            "konflux-component-name": "multicluster-observability-addon", "publish-name": "acm-multicluster-observability-addon-rhel9"},
             {"image-key": "multicluster_observability_operator",         "konflux-component-name": "multicluster-observability-operator", "publish-name": "multicluster-observability-rhel9-operator"},
             {"image-key": "multicluster_operators_application",          "konflux-component-name": "multicluster-operators-application", "publish-name": "multicluster-operators-application-rhel9"},
             {"image-key": "multicluster_operators_channel",              "konflux-component-name": "multicluster-operators-channel", "publish-name": "multicluster-operators-channel-rhel9"},
@@ -72,7 +72,7 @@
               "image-ref": "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.15.0"
             },{
               "image-key": "volsync",
-              "image-ref": "registry.redhat.io/rhacm2/volsync-container:rhacm-2.13-rhel-9-container-candidate"
+              "image-ref": "registry.redhat.io/rhacm2/volsync-rhel9:v0.12.1-2"
             }
         ]
     }


### PR DESCRIPTION
There were some problems with how the images were defined. Adding fixes for:
- cluster backup
- volsync
- memcache exporter
- obs addon