### PR TITLE
Get the acm kube-rbac-proxy

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -26,6 +26,7 @@
             {"image-key": "insights_client",                             "konflux-component-name": "insights-client", "publish-name": "insights-client-rhel9"},
             {"image-key": "insights_metrics",                            "konflux-component-name": "insights-metrics", "publish-name": "insights-metrics-rhel9"},
             {"image-key": "klusterlet_addon_controller",                 "konflux-component-name": "klusterlet-addon-controller", "publish-name": "klusterlet-addon-controller-rhel9"},
+            {"image-key": "kube_rbac_proxy",                             "konflux-component-name": "kube-rbac-proxy", "publish-name": "kube-rbac-proxy-rhel9"},
             {"image-key": "kube_state_metrics",                          "konflux-component-name": "kube-state-metrics", "publish-name": "kube-state-metrics-rhel9"},
             {"image-key": "memcached_exporter",                          "konflux-component-name": "memcached-exporter", "publish-name": "MEMCACHED_EXPORTER-rhel9"},
             {"image-key": "metrics_collector",                           "konflux-component-name": "metrics-collector", "publish-name": "metrics-collector-rhel9"},
@@ -67,9 +68,6 @@
             },{
               "image-key": "memcached",
               "image-ref": "registry.redhat.io/rhel9/memcached:latest"
-            },{
-              "image-key": "ose_kube_rbac_proxy",
-              "image-ref": "registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.15.0"
             },{
               "image-key": "volsync",
               "image-ref": "registry.redhat.io/rhacm2/volsync-rhel9:v0.12.1-2"


### PR DESCRIPTION
We were getting the wrong one I think as a temporary solution, switching back to the correct source for this image