### PR TITLE
Add the flightctl as external images for now

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -63,6 +63,21 @@
               "image-key": "configmap_reloader",
               "image-ref": "registry.redhat.io/openshift4/ose-configmap-reloader-rhel9:v4.16.0-202411190033.p0.gdc91ddc.assembly.stream.el9"
             },{
+              "image-key": "flightctl_api",
+              "image-ref": "registry.redhat.io/rhacm2/acm-flightctl-api-rhel9:v2.13"
+            },{
+              "image-key": "flightctl_ocp_ui",
+              "image-ref": "registry.redhat.io/rhacm2/acm-flightctl-ocp-ui-rhel9:v2.13"
+            },{
+              "image-key": "flightctl_periodic",
+              "image-ref": "registry.redhat.io/rhacm2/acm-flightctl-periodic-rhel9:v2.13"
+            },{
+              "image-key": "flightctl_ui",
+              "image-ref": "registry.redhat.io/rhacm2/acm-flightctl-ui-rhel9:v2.13"
+            },{
+              "image-key": "flightctl_worker",
+              "image-ref": "registry.redhat.io/rhacm2/acm-flightctl-worker-rhel9:v2.13"
+            },{
               "image-key": "postgresql_16",
               "image-ref": "registry.redhat.io/rhel8/postgresql-16:1-42.1741813436"
             },{


### PR DESCRIPTION
These will need to be adjusted when we get the right locations for the flightctl images.  For now we are pointing to the latest 2.13 images.