### PR TITLE
[ACM-20421] Removed the "Upgrading from release 2.4" section from the ACM CSV

### DIFF
--- a/config/acm-csv-template.yaml
+++ b/config/acm-csv-template.yaml
@@ -109,20 +109,6 @@ spec:
     If you are creating the `MultiClusterHub` resource using the OperatorHub UI, switch to
     the YAML view for the resource in order to insert the annotation.
 
-    #### Upgrading from release 2.4
-
-    The special considerations described above also apply when upgrading from
-    Red Hat Advanced Cluster Management for Kubernetes release 2.4.
-
-    - If you are using a filtered mirror catalog, update your catalog-building procedures to
-      ensure that the `multicluster-engine` package is included in your mirror catalog.
-
-    - Before changing the update channel to trigger the update, edit your existing
-      `MultiClusterHub` resource to add the `mce-subscription-spec` annotation as shown
-       in the example above so that the upgraded version of the
-       Red Hat Advanced Cluster Management for Kubernetes knows the correct catalog source
-       to use to find the `multicluster-engine` package.
-
     ### Where to find more installation information
 
     You can find additional installation guidance in the


### PR DESCRIPTION
# Description

During the ACM 2.14 release, it was observed that the ACM CSV still included information related to ACM 2.4, which is no longer supported. This PR removes the outdated section to ensure the CSV content is more relevant to the current release.

## Related Issue

https://issues.redhat.com/browse/ACM-20421

## Changes Made

Removed outdated ACM 2.4 content from the ACM CSV documentation.

## Screenshots (if applicable)

![image (4)](https://github.com/user-attachments/assets/8e5060f3-2692-4572-9009-b6be1ab98159)

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @gparvin @cameronmwall 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.