### PR TITLE
Update volsync to latest konflux build

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -89,7 +89,7 @@
               "image-ref": "registry.redhat.io/rhel9/memcached:latest"
             },{
               "image-key": "ose_kube_rbac_proxy",
-              "image-ref": "quay.io/acm-d/ose-kube-rbac-proxy-rhel9:v4.18.0-202505200035.p0.g526498a.assembly.stream.el9"
+              "image-ref": "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.18.0-202505200035.p0.g526498a.assembly.stream.el9"
             },{
               "image-key": "volsync",
               "image-ref": "registry.redhat.io/rhacm2/volsync-rhel9:v0.13.0-konflux-latest"


### PR DESCRIPTION
- Using konflux build v0.13.0-konflux-00f7280
- Also puts back the ose_kube_rbac_proxy image ref

# Description

Updates the volsync related image to the latest konflux build.

Ultimately this should be automated, but doing this manually for the moment (and as a first test).

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
