### PR TITLE
Change how the observability addon image is being published

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -26,7 +26,7 @@
             {"image-key": "memcached_exporter",                          "konflux-component-name": "memcached-exporter", "publish-name": "memcached-exporter-rhel9"},
             {"image-key": "metrics_collector",                           "konflux-component-name": "metrics-collector", "publish-name": "metrics-collector-rhel9"},
             {"image-key": "multicloud_integrations",                     "konflux-component-name": "multicloud-integrations", "publish-name": "multicloud-integrations-rhel9"},
-            {"image-key": "multicluster_observability_addon",            "konflux-component-name": "multicluster-observability-addon", "publish-name": "acm-multicluster-observability-addon-rhel9"},
+            {"image-key": "multicluster_observability_addon",            "konflux-component-name": "multicluster-observability-addon", "publish-name": "multicluster-observability-addon-rhel9"},
             {"image-key": "multicluster_observability_operator",         "konflux-component-name": "multicluster-observability-operator", "publish-name": "multicluster-observability-rhel9-operator"},
             {"image-key": "multicluster_operators_application",          "konflux-component-name": "multicluster-operators-application", "publish-name": "multicluster-operators-application-rhel9"},
             {"image-key": "multicluster_operators_channel",              "konflux-component-name": "multicluster-operators-channel", "publish-name": "multicluster-operators-channel-rhel9"},


### PR DESCRIPTION
The observability addon images are being pushed to multicluster-observability-addon-rhel9,
not to acm-multicluster-observability-addon-rhel9.  Hoping this is the right one to pick.

Refs:
 - https://issues.redhat.com/browse/ACM-21584

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
