### PR TITLE
[ACM-21279 Updated ACM manifest config to include Volsync v0.13 tag

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -91,10 +91,8 @@
               "image-key": "ose_kube_rbac_proxy",
               "image-ref": "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.18.0-202507081733.p0.g526498a.assembly.stream.el9"
             },{
-              "image-key":          "volsync",
-              "note-1":             "This is a placeholder image reference",
-              "pre-pub-image-ref":  "quay.io/acm-d/volsync-rhel9:v0.13.0-konflux-latest",
-              "as-pub-remote":      "registry.redhat.io/rhacm2"
+              "image-key": "volsync",
+              "image-ref": "registry.redhat.io/rhacm2/volsync-rhel9:v0.13"
             }
         ]
     }


### PR DESCRIPTION
# Description

Volsync recently GA’d version `v0.13`, so we need to update the bundle manifest to include the latest image for their component.

## Related Issue

https://issues.redhat.com/browse/ACM-21279

## Changes Made

Updated the Volsync component `image-ref` to version `v0.13`.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @gparvin @cameronmwall 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
