### PR TITLE
acm 2.15 use latest volsync dev image (v0.14.0)

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -90,10 +90,12 @@
               "image-ref": "registry.redhat.io/rhel9/memcached:9.6-1752503850"
             },{
               "image-key": "ose_kube_rbac_proxy",
-              "image-ref": "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.18.0-202507081733.p0.g526498a.assembly.stream.el9"
+              "image-ref": "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.19.0-202507291138.p0.g5912775.assembly.stream.el9"
             },{
-              "image-key": "volsync",
-              "image-ref": "registry.redhat.io/rhacm2/volsync-rhel9:v0.13"
+              "image-key":          "volsync",
+              "note-1":             "This is a placeholder image reference",
+              "pre-pub-image-ref":  "quay.io/acm-d/volsync-rhel9:v0.14.0-konflux-latest",
+              "as-pub-remote":      "registry.redhat.io/rhacm2"
             }
         ]
     }


### PR DESCRIPTION
# Description

Please provide a brief description of the purpose of this pull request.

- Update ACM 2.15 to use the external image for the latest dev version of volsync (latest v0.14.0 konflux build).
- Also update the ose-kube-rbac-proxy image used by volsync to the latest v4.19 one.

Ultimately after volsync v0.14.0 ships we'll have to point to the offficial location in registry.redhat.io (and the v0.14 tag) as we did for the previous release.

## Related Issue

https://issues.redhat.com/browse/ACM-23209

## Changes Made


## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
