### PR TITLE
Added multicluster-role-assignment component to ACM 2.15 bundle manifest

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -32,6 +32,7 @@
             {"image-key": "multicluster_operators_application",          "konflux-component-name": "multicluster-operators-application", "publish-name": "multicluster-operators-application-rhel9"},
             {"image-key": "multicluster_operators_channel",              "konflux-component-name": "multicluster-operators-channel", "publish-name": "multicluster-operators-channel-rhel9"},
             {"image-key": "multicluster_operators_subscription",         "konflux-component-name": "multicluster-operators-subscription", "publish-name": "multicluster-operators-subscription-rhel9"},
+            {"image-key": "multicluster_role_assignment",                "konflux-component-name": "multicluster-role-assignment", "publish-name": "multicluster-role-assignment-rhel9"},
             {"image-key": "multiclusterhub_operator",                    "konflux-component-name": "multiclusterhub-operator", "publish-name": "multiclusterhub-rhel9"},
             {"image-key": "node_exporter",                               "konflux-component-name": "node-exporter", "publish-name": "node-exporter-rhel9"},
             {"image-key": "observatorium",                               "konflux-component-name": "observatorium", "publish-name": "observatorium-rhel9"},


### PR DESCRIPTION
# Description

In ACM 2.15, the `multicluster-role-assignment` component was added to the release. As a result, we need to include a new entry for it in the ACM 2.15 bundle manifest generation.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Added `multicluster-role-assignment` to the ACM 2.15 manifest.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @cameronmwall @gparvin 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
