### PR TITLE
Update external images for the 2.14.1 acm release

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -56,40 +56,40 @@
         "image-list": [
             {
               "image-key": "configmap_reloader",
-              "image-ref": "registry.redhat.io/openshift4/ose-configmap-reloader-rhel9:v4.16.0-202507081835.p0.gdc91ddc.assembly.stream.el9"
+              "image-ref": "registry.redhat.io/openshift4/ose-configmap-reloader-rhel9@sha256:7f86f9a33460384c60e62813e665b89bb6288aa3a4d56ca09040063d7b02b9bc"
             },{
               "image-key": "flightctl_api",
-              "image-ref": "registry.redhat.io/rhem/flightctl-api-rhel9:v0.7.2"
+              "image-ref": "registry.redhat.io/rhem/flightctl-api-rhel9@sha256:b8f8f931f498855461ff997f73470fd957a5f32719a62c993f07050e75d76bfe"
             },{
               "image-key": "flightctl_ocp_ui",
-              "image-ref": "registry.redhat.io/rhem/flightctl-ui-ocp-rhel9:v0.7.2"
+              "image-ref": "registry.redhat.io/rhem/flightctl-ui-ocp-rhel9@sha256:973eb3ca3da32c87ba308928a21fbd25514b2f6a6662300d4928479cb554cff3"
             },{
               "image-key": "flightctl_periodic",
-              "image-ref": "registry.redhat.io/rhem/flightctl-periodic-rhel9:v0.7.2"
+              "image-ref": "registry.redhat.io/rhem/flightctl-periodic-rhel9@sha256:ee59f307e468e2b7b38f7c040898d587d441f8fb3d59cb022ae23e4717739e3f"
             },{
               "image-key": "flightctl_ui",
-              "image-ref": "registry.redhat.io/rhem/flightctl-ui-rhel9:v0.7.2"
+              "image-ref": "registry.redhat.io/rhem/flightctl-ui-rhel9@sha256:940c0564ced75b7912d3ffc923a1f6bab9aed0f4a52962f7f894d08937b7d37e"
             },{
               "image-key": "flightctl_worker",
-              "image-ref": "registry.redhat.io/rhem/flightctl-worker-rhel9:v0.7.2"
+              "image-ref": "registry.redhat.io/rhem/flightctl-worker-rhel9@sha256:1b1f6f85af0910f1acd029f54a608b25d3a2977c3d8b323266391543324305b4"
             },{
               "image-key": "flightctl_cli_artifacts",
-              "image-ref": "registry.redhat.io/rhem/flightctl-cli-artifacts-rhel9:v0.7.2"
+              "image-ref": "registry.redhat.io/rhem/flightctl-cli-artifacts-rhel9@sha256:3491ec932d90112e89f3a4cebe5bdd9ed6a7811f116df43bab8bb5f827129361"
             },{
               "image-key": "origin_cli",
-              "image-ref": "registry.redhat.io/openshift4/ose-cli-rhel9:v4.16.0-202507081835.p0.gee354f6.assembly.stream.el9"
+              "image-ref": "registry.redhat.io/openshift4/ose-cli-rhel9@sha256:afa4337370e8ea6da0e25d62c7197157b85281916a1fff4c881eafaf14a2c3e8"
             },{
               "image-key": "redis_7_c9s",
-              "image-ref": "registry.redhat.io/rhel9/redis-7:9.6-1752567986"
+              "image-ref": "registry.redhat.io/rhel9/redis-7@sha256:b4f58ad83ab8719a2e102f38ee526546cd1d56428901afc3add45c9a0e2a2f12"
             },{
               "image-key": "postgresql_16",
-              "image-ref": "registry.redhat.io/rhel8/postgresql-16:1-1752582967"
+              "image-ref": "registry.redhat.io/rhel8/postgresql-16@sha256:776f420f734f9c1d6e0589fc6d9acee8f1c2bfd1f838348360bb9db584920602"
             },{
               "image-key": "memcached",
-              "image-ref": "registry.redhat.io/rhel9/memcached:9.6-1752503850"
+              "image-ref": "registry.redhat.io/rhel9/memcached@sha256:42a0c2506b38ce9f5ee744a299cb135781186e628fdf7c09d2d35ba3b6decef8"
             },{
               "image-key": "ose_kube_rbac_proxy",
-              "image-ref": "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.18.0-202507081733.p0.g526498a.assembly.stream.el9"
+              "image-ref": "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:467557f453bde3feaa0129f38c52fba00c3b98acddbf8978bf21ef13a9890fab"
             },{
               "image-key": "volsync",
               "image-ref": "registry.redhat.io/rhacm2/volsync-rhel9:v0.13"


### PR DESCRIPTION
Update the external images for acm.  Pinned all digests except volsync -- which I think could have been pinned too since there's a 0.13.1 image but it looks like we will pick it up anyway.

# Description

Please provide a brief description of the purpose of this pull request.

## Related Issue

If applicable, please reference the issue(s) that this pull request addresses.

## Changes Made

Provide a clear and concise overview of the changes made in this pull request.

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
