### PR TITLE
[ACM-24756] Added external obo-prometheus-rhel9-operator image to ACM 2.15 bundle

### DIFF
--- a/config/acm-manifest-gen-config.json
+++ b/config/acm-manifest-gen-config.json
@@ -105,6 +105,9 @@
               "image-key": "memcached",
               "image-ref": "registry.redhat.io/rhel9/memcached:9.6-1752503850"
             },{
+              "image-key": "obo_prometheus_rhel9_operator",
+              "image-ref": "registry.redhat.io/cluster-observability-operator/obo-prometheus-rhel9-operator:1.2.2-1752503986"
+            },{
               "image-key": "ose_kube_rbac_proxy",
               "image-ref": "registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.19.0-202507291138.p0.g5912775.assembly.stream.el9"
             },{


### PR DESCRIPTION
# Description

Add the `obo-prometheus-rhel9-operator` image to the installation bundle to ensure it is included in the `open-cluster-management-observability/images-list` ConfigMap.

## Related Issue

https://issues.redhat.com/browse/ACM-24756

## Changes Made

Added `obo_prometheus_rhel9_operator` image key reference to `acm-manifest-gen-config.json`

## Screenshots (if applicable)

Add screenshots or GIFs that demonstrate the changes visually, if relevant.

## Checklist

- [ ] I have tested the changes locally and they are functioning as expected.
- [ ] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [ ] I have ensured that my code follows the project's coding standards.
- [ ] I have checked for any potential security issues and addressed them.
- [ ] I have added necessary comments to the code, especially in complex or unclear sections.
- [ ] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Add any additional notes, context, or information that might be helpful for reviewers.

## Reviewers

Tag the appropriate reviewers who should review this pull request. To add reviewers, please add the following line: `/cc @reviewer1 @reviewer2`

/cc @gparvin 

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.
