### PR TITLE
Fix skipRange for 2.17.x to 5.0 upgrades

### DIFF
--- a/config/acm-bundle-gen-config
+++ b/config/acm-bundle-gen-config
@@ -43,11 +43,16 @@ cfg_eus_release_cadence=3
 
 # Special configuration for version resync scenarios:
 # Use this to override the automatic skipRange calculation when doing version jumps.
-# Example: If jumping from 2.18 to 5.0, set: cfg_min_upgrade_version="2.17.0"
+# Example: If jumping from 2.18 to 5.0, set: cfg_min_upgrade_version="2.17.0-0"
 #
 # NOTE: For normal sequential releases, leave this commented out to use automatic
 # skipRange calculation. Only uncomment and set this for version jumps.
-cfg_min_upgrade_version="2.17.0"
+#
+# IMPORTANT: When using build suffixes (add_iteration_suffix=1), always append "-0"
+# to the minimum version to match pre-release builds. In semver, "2.17.0-132" is a
+# pre-release version that sorts BEFORE "2.17.0". Using "2.17.0-0" as the minimum
+# ensures the skipRange matches all 2.17.0-* builds AND the GA 2.17.0 release.
+cfg_min_upgrade_version="2.17.0-0"
 
 #-----------------------------------------------------------------
 # Config properties that are unique for each product (ACM vs. MCE)


### PR DESCRIPTION
# Description

This PR fixes the semantic versioning issue preventing upgrades from ACM 2.17.0-132 to 5.0.0-X by updating the `cfg_min_upgrade_version` from `2.17.0` to `2.17.0-0`.

## Related Issue

Addresses the issue where OLM does not create InstallPlans when attempting to upgrade from ACM 2.17 (dev builds) to ACM 5.0.

## Changes Made

**File Modified:** `config/acm-bundle-gen-config`

**Change:**
- Updated `cfg_min_upgrade_version="2.17.0"` to `cfg_min_upgrade_version="2.17.0-0"`
- Added documentation explaining the semver behavior

**Root Cause:**
In Semantic Versioning 2.0.0 (used by OLM), pre-release versions (e.g., `2.17.0-132`) have **lower precedence** than release versions (`2.17.0`). This means:
```
2.17.0-132 < 2.17.0  (in semver ordering)
```

The previous skipRange `>=2.17.0` was excluding all `2.17.0-*` builds, preventing OLM from finding an upgrade path.

**Solution:**
Using `2.17.0-0` as the minimum ensures the skipRange matches:
- ✅ All 2.17.0 pre-release builds (`2.17.0-0`, `2.17.0-132`, etc.)
- ✅ GA release `2.17.0` (if shipped without suffix)
- ✅ Future patch releases (`2.17.1+`)

**Generated CSV Change:**
```yaml
# Before:
olm.skipRange: '>=2.17.0 <5.0.0-X'  # Blocks 2.17.0-132

# After:
olm.skipRange: '>=2.17.0-0 <5.0.0-X'  # Allows 2.17.0-132
```

## Screenshots (if applicable)

N/A - Configuration file change only.

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [ ] I have added/updated relevant unit tests (if applicable).
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have added necessary comments to the code, especially in complex or unclear sections.
- [x] I have rebased my branch on top of the latest release-5.0 branch.

## Additional Notes

**Testing Verification:**
The semantic versioning behavior was verified using the `semver` Python library (which implements semver 2.0.0 spec):

```
Is 2.17.0-132 >= 2.17.0?    ❌ False (BROKEN)
Is 2.17.0-132 >= 2.17.0-0?  ✅ True  (FIXED)
```

**Impact:**
- Fixes OLM upgrade path from current dev builds (2.17.0-132)
- Compatible with future GA release (2.17.0)
- No changes needed when shipping GA
- Works for any future 2.17.x patch releases

**No changes required before GA** - the `-0` suffix works for both pre-release and GA versions.

## Reviewers

/cc @reviewers

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [x] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the release-5.0 branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated version configuration to correctly handle upgrade and version-jump scenarios, ensuring proper compatibility matching between pre-release builds and general availability releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->