### PR TITLE
Add transition channel for dual-channel publication

### DIFF
--- a/config/acm-bundle-gen-config
+++ b/config/acm-bundle-gen-config
@@ -69,6 +69,11 @@ olm_package="$cfg_pkg_name" # Alternate name for this config variable
 # Override the default "release" prefix to use "stable" for ACM 5.0+
 cfg_release_channel_prefix="stable"
 
+# Transition channel prefix for dual-channel publication during migration:
+# Publish to both stable-5.0 and release-5.0 channels to support automation
+# expecting the old channel name during the transition period.
+cfg_transition_channel_prefix="release"
+
 # Pathname (in bundle repo) of the CSV template file.
 cfg_csv_template="config/acm-csv-template.yaml"
 


### PR DESCRIPTION
## Summary
Enable dual-channel publication to both `stable-5.0` and `release-5.0` during the channel naming transition period.

## Problem
PR #2770 changed ACM 5.0 from `release-5.0` to `stable-5.0` channel naming. This breaks automation expecting the `release-5.0` channel.

From Slack discussion:
> **Matthew Smigielski**: This will break a lot of things.
> **Gus Parvin**: There was supposed to be a transition period where both channels are available.

## Solution
Set `cfg_transition_channel_prefix="release"` in bundle generation config to publish to both channels:
- Primary: `stable-5.0` (new naming convention, aligns with MCE)
- Transition: `release-5.0` (old naming, supports existing automation)

## Result
Next snapshot generation will produce:
```yaml
operators.operatorframework.io.bundle.channels.v1: release-5.0,stable-5.0
operators.operatorframework.io.bundle.channel.default.v1: stable-5.0
```

Both channels point to same bundle. Automation can use either channel name.

## Dependencies
**Blocked by**: stolostron/release#868 (adds transition channel support to bundle generation tooling)

Merge order:
1. Merge stolostron/release#868 first
2. Then merge this PR
3. Next snapshot will apply dual-channel config

## Testing Plan
After merge:
1. Trigger bundle generation (manual or automatic snapshot)
2. Verify `metadata/annotations.yaml` contains both channels
3. Test that OLM recognizes both channel names:
   ```bash
   oc get packagemanifests -n openshift-marketplace advanced-cluster-management -o json | jq '.status.channels[].name'
   ```

## Cleanup
Once automation is updated to use `stable-5.0`, remove the transition channel:
- Delete `cfg_transition_channel_prefix="release"` line from config
- Next snapshot will publish only to `stable-5.0`

## Related
- Original channel change: #2770
- Slack discussion: ACM channel naming alignment with MCE

🤖 Generated with Claude Code