### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,30 @@
+FROM scratch
+
+COPY ./manifests /manifests
+COPY ./metadata /metadata
+COPY ./extras /extras
+
+LABEL com.redhat.delivery.operator.bundle="true" \
+      operators.operatorframework.io.bundle.mediatype.v1="registry+v1" \
+      operators.operatorframework.io.bundle.manifests.v1="manifests/" \
+      operators.operatorframework.io.bundle.metadata.v1="metadata/" \
+      operators.operatorframework.io.bundle.package.v1="advanced-cluster-management" \
+      operators.operatorframework.io.bundle.channels.v1="release-2.16" \
+      com.redhat.openshift.versions="v4.18-v4.22"
+
+LABEL com.redhat.component="acm-operator-bundle-container" \
+      name="rhacm2/acm-operator-bundle" \
+      version="2.16.1-392" \
+      summary="acm-operator-bundle" \
+      io.openshift.expose-services="" \
+      io.openshift.tags="data,images" \
+      io.k8s.display-name="acm-operator-bundle" \
+      io.k8s.description="Operator bundle for Red Hat Advanced Cluster Management"  \
+      maintainer="['acm-component-maintainers@redhat.com']" \
+      description="acm-operator-bundle" \
+      konflux.additional-tags="v2.16.1-392,snapshot-release-acm-216-20260505-061924-000" \
+      vendor="Red Hat, Inc." \
+      url="https://github.com/stolostron/acm-operator-bundle" \
+      release="2.16.1-392" \
+      distribution-scope="public" \
+      cpe="cpe:/a:redhat:acm:2.16::el9"


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)