### PR TITLE
Update release version mappings to match branch versions

### DIFF
--- a/.github/release-version-mapping.yaml
+++ b/.github/release-version-mapping.yaml
@@ -4,11 +4,11 @@
 
 release_mappings:
   release-2.11: "2.11.10"
-  release-2.12: "2.12.8"  
-  release-2.13: "2.13.6"
+  release-2.12: "2.12.9"
+  release-2.13: "2.13.7"
   release-2.14: "2.14.3"
-  release-2.15: "2.15.2"
-  release-2.16: "2.16.1"
+  release-2.15: "2.15.3"
+  release-2.16: "2.16.2"
   release-2.17: "2.17.0"
   release-5.0: "5.0.0"
   # Add new release mappings here as needed


### PR DESCRIPTION
## Summary
Sync release-version-mapping.yaml with actual Z_RELEASE_VERSION values in release branches.

## Changes
- `release-2.12`: 2.12.8 → 2.12.9
- `release-2.13`: 2.13.6 → 2.13.7
- `release-2.15`: 2.15.2 → 2.15.3
- `release-2.16`: 2.16.1 → 2.16.2

## Context
Main branch mapping was stale. Release branches already had newer patch versions built and merged. This update ensures the mapping file reflects current state.

## Testing
Once merged, update-release-versions workflow will run and verify mappings match branch versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version configurations across multiple release branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->