### PR TITLE
[release-5.1] Enable AllNamespaces install mode

### DIFF
--- a/config/acm-csv-template.yaml
+++ b/config/acm-csv-template.yaml
@@ -142,7 +142,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: false
+  - supported: true
     type: AllNamespaces
   apiservicedefinitions:
     required: "*Merge* to List"


### PR DESCRIPTION
## Summary
- Enable AllNamespaces install mode in CSV template (changed from `supported: false` to `supported: true`)

## Context
Allows ACM operator to be installed across all namespaces in cluster instead of restricted to OwnNamespace only.

## Test plan
- [ ] Verify generated CSV includes `AllNamespaces` install mode with `supported: true`
- [ ] Test operator installation in AllNamespaces mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)