### PR TITLE
feat: CVE Trend Dashboard with Automated Weekly Tracking

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -140,14 +140,15 @@ jobs:
           mkdir -p ~/.config/containers
 
           # Log in to quay.io using podman (writes to correct location)
-          echo "${{ secrets.QUAY_IO_ACMD_RGY_PASSWORD }}" \
+          # Use printf to avoid echo potentially exposing secrets in logs
+          printf '%s' "${{ secrets.QUAY_IO_ACMD_RGY_PASSWORD }}" \
             | podman login -u="${{ vars.QUAY_IO_ACMD_RGY_USERNAME }}" --password-stdin quay.io
 
           # Also login to other registries that images might come from
-          echo "${{ secrets.REGISTRY_REDHAT_IO_RGY_PASSWORD }}" \
+          printf '%s' "${{ secrets.REGISTRY_REDHAT_IO_RGY_PASSWORD }}" \
             | podman login -u="${{ vars.REGISTRY_REDHAT_IO_RGY_USERNAME }}" --password-stdin registry.redhat.io
 
-          echo "${{ secrets.REGISTRY_STAGE_REDHAT_IO_RGY_PASSWORD }}" \
+          printf '%s' "${{ secrets.REGISTRY_STAGE_REDHAT_IO_RGY_PASSWORD }}" \
             | podman login -u="${{ vars.REGISTRY_STAGE_REDHAT_IO_RGY_USERNAME }}" --password-stdin registry.stage.redhat.io
 
           # Verify auth file exists

--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: 'HIGH,CRITICAL'
         type: string
+      auto_commit:
+        description: 'Auto-commit results to main branch'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   cve-scan:
@@ -313,7 +318,7 @@ jobs:
     name: Aggregate Results and Auto-Commit
     runs-on: ubuntu-latest
     needs: cve-scan
-    if: always() && github.event_name == 'schedule'  # Only auto-commit on scheduled runs
+    if: always() && (github.event_name == 'schedule' || inputs.auto_commit == true)
 
     steps:
       - name: Checkout main branch

--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -1,7 +1,7 @@
 name: Weekly CVE Scan
 
 permissions:
-  contents: read
+  contents: write  # Need write for auto-commit
 
 on:
   schedule:
@@ -224,6 +224,14 @@ jobs:
           ICSP_CONFIG: icsp-config.json
           EXTRAS_DIR: extras
           REPORTS_DIR: reports
+          GITHUB_RUN_ID: ${{ github.run_id }}
+
+      - name: Generate trend dashboard
+        if: always()
+        run: |
+          echo "Generating CVE trend dashboard for ${{ env.RELEASE_BRANCH }}..."
+          make cve-trends-html RELEASE=${{ env.RELEASE_BRANCH }} || echo "⚠️  Trend dashboard generation failed (may be first run)"
+        continue-on-error: true
 
       - name: Send summary to Slack
         if: always()
@@ -262,6 +270,31 @@ jobs:
           path: reports/
           retention-days: 90
 
+      - name: Upload trend dashboard
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trend-dashboard-${{ env.RELEASE_BRANCH }}
+          path: reports/trends/*.html
+          retention-days: 90
+        continue-on-error: true
+
+      - name: Store scan results to history
+        if: always()
+        run: |
+          echo "Storing scan results to reports/trends/${{ env.RELEASE_BRANCH }}-history.json..."
+          make store-scan-result RELEASE=${{ env.RELEASE_BRANCH }}
+        continue-on-error: true
+
+      - name: Upload history and trends
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: history-${{ env.RELEASE_BRANCH }}
+          path: reports/trends/${{ env.RELEASE_BRANCH }}-history.json
+          retention-days: 90
+        continue-on-error: true
+
       - name: Check for critical CVEs
         run: |
           # Count critical CVEs and fail if threshold exceeded
@@ -273,3 +306,75 @@ jobs:
             echo "Review the reports in the artifacts section"
           fi
         continue-on-error: true
+
+  # Aggregate and commit after all releases scanned
+  aggregate-and-commit:
+    name: Aggregate Results and Auto-Commit
+    runs-on: ubuntu-latest
+    needs: cve-scan
+    if: always() && github.event_name == 'schedule'  # Only auto-commit on scheduled runs
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements.txt
+
+      - name: Download all history artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: history-*
+          path: downloaded-history/
+          merge-multiple: false
+
+      - name: Merge history files
+        run: |
+          echo "Merging history files from artifacts..."
+          mkdir -p reports/trends
+
+          # Copy each release history file
+          for history_dir in downloaded-history/history-*/; do
+            if [ -d "$history_dir" ]; then
+              cp "$history_dir"*.json reports/trends/ || true
+            fi
+          done
+
+          ls -la reports/trends/
+          echo "✓ History files merged"
+
+      - name: Generate multi-release dashboard
+        run: |
+          echo "Generating multi-release comparison dashboard..."
+          make cve-trends-multi
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add reports/trends/
+
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update CVE trend dashboards (automated weekly scan)
+
+Weekly CVE scan results for:
+$(ls reports/trends/*-history.json | xargs -n1 basename | sed 's/-history.json//' | sed 's/^/- /')
+
+Generated: $(date -u '+%Y-%m-%d %H:%M UTC')
+Run: ${{ github.run_id }}"
+
+            git push
+            echo "✓ Changes committed and pushed"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help list-images list-images-full check-dummy-shas verify-images verify-images-icsp verify-images-podman verify-images-arm64 verify-images-amd64 verify-images-ppc64le verify-images-s390x verify-images-latest verify-release scan-release scan-cves scan-cves-icsp scan-cves-json scan-cves-json-icsp image-report clean-reports check-tools install-deps all-checks all-checks-latest full-scan make-scripts-executable setup-release
+.PHONY: help list-images list-images-full check-dummy-shas verify-images verify-images-icsp verify-images-podman verify-images-arm64 verify-images-amd64 verify-images-ppc64le verify-images-s390x verify-images-latest verify-release scan-release scan-cves scan-cves-icsp scan-cves-json scan-cves-json-icsp image-report clean-reports check-tools install-deps all-checks all-checks-latest full-scan make-scripts-executable setup-release store-scan-result cve-trends cve-trends-html cve-trends-multi
 
 # Configuration
 export EXTRAS_DIR ?= extras
@@ -34,6 +34,11 @@ help: ## Show this help message
 	@echo "  make scan-cves IMAGE_KEY=multiclusterhub_operator     # Scan single component"
 	@echo "  make scan-cves RELEASE=release-2.17 IMAGE_KEY=...     # Release + component"
 	@echo "  make scan-cves SCAN_SEVERITY=CRITICAL,HIGH,MEDIUM     # Custom severity"
+	@echo ""
+	@echo "CVE trend tracking:"
+	@echo "  make cve-trends RELEASE=release-2.17       # Show trend analysis"
+	@echo "  make cve-trends-html RELEASE=release-2.17  # Generate HTML dashboard"
+	@echo "  make cve-trends-multi                      # Multi-release comparison dashboard"
 
 list-images: ## List all images from extras/*.json files
 	@python3 $(SCRIPTS_DIR)/list_images.py
@@ -85,10 +90,12 @@ scan-cves-icsp: ## Scan images using ICSP registry redirects (text output)
 scan-cves-json: ## Scan images and output results in JSON format
 	$(setup-if-release)
 	@OUTPUT_JSON=true python3 $(SCRIPTS_DIR)/scan_cves.py $(SCAN_ARGS)
+	@$(MAKE) store-scan-result
 
 scan-cves-json-icsp: ## Scan images with ICSP and output JSON (for Slack reports)
 	$(setup-if-release)
 	@ICSP_CONFIG=icsp-config.json OUTPUT_JSON=true python3 $(SCRIPTS_DIR)/scan_cves.py $(SCAN_ARGS)
+	@$(MAKE) store-scan-result
 
 image-report: ## Generate comprehensive image report
 	@python3 $(SCRIPTS_DIR)/image_report.py
@@ -98,6 +105,18 @@ slack-cve-report: ## Send CVE scan summary to Slack (requires SLACK_WEBHOOK_URL)
 
 slack-cve-report-detailed: ## Send detailed CVE report to Slack
 	@SLACK_FORMAT=detailed python3 $(SCRIPTS_DIR)/slack_cve_report.py
+
+store-scan-result: ## Store latest scan results for trend tracking
+	@python3 $(SCRIPTS_DIR)/store_scan_results.py --reports-dir $(REPORTS_DIR) --extras-dir $(EXTRAS_DIR) $(if $(RELEASE),--release $(RELEASE),)
+
+cve-trends: ## Generate CVE trend report (Usage: make cve-trends RELEASE=release-2.17)
+	@python3 $(SCRIPTS_DIR)/cve_trends.py --reports-dir $(REPORTS_DIR) --release $(or $(RELEASE),$(error RELEASE not specified. Use: make cve-trends RELEASE=release-2.17))
+
+cve-trends-html: ## Generate HTML trend dashboard (Usage: make cve-trends-html RELEASE=release-2.17)
+	@python3 $(SCRIPTS_DIR)/generate_trend_report.py --reports-dir $(REPORTS_DIR) --release $(or $(RELEASE),$(error RELEASE not specified. Use: make cve-trends-html RELEASE=release-2.17))
+
+cve-trends-multi: ## Generate multi-release comparison dashboard with tabs
+	@python3 $(SCRIPTS_DIR)/generate_multi_release_dashboard.py --reports-dir $(REPORTS_DIR)
 
 setup-release: ## Set up extras/ from a release branch (Usage: make setup-release RELEASE=release-2.17)
 	@bash $(SCRIPTS_DIR)/setup_release.sh $(RELEASE)

--- a/scripts/analyze_cve_blast_radius.py
+++ b/scripts/analyze_cve_blast_radius.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Analyze CVE blast radius - which CVEs affect most components"""
+
+def analyze_blast_radius(scan, top_n=10):
+    """Analyze which CVEs affect the most components
+
+    Args:
+        scan: Scan record with summary.cve_details
+        top_n: Number of top CVEs to return
+
+    Returns:
+        List of dicts with CVE analysis
+    """
+    cve_details = scan.get('summary', {}).get('cve_details', [])
+
+    if not cve_details:
+        return []
+
+    # Group by CVE ID
+    cve_map = {}
+    for detail in cve_details:
+        cve_id = detail.get('cve_id')
+        severity = detail.get('severity')
+        component = detail.get('component')
+        fixable = detail.get('fixable', False)
+        fixed_versions = detail.get('fixed_versions', [])
+
+        if cve_id not in cve_map:
+            cve_map[cve_id] = {
+                'cve_id': cve_id,
+                'severity': severity,
+                'components': set(),
+                'fixable': fixable,
+                'fixed_versions': set(),
+                'sample_detail': detail  # Keep one detail for description extraction
+            }
+
+        cve_map[cve_id]['components'].add(component)
+        # If ANY instance is fixable, mark as fixable
+        if fixable:
+            cve_map[cve_id]['fixable'] = True
+        # Collect all fixed versions
+        if fixed_versions:
+            for ver in fixed_versions:
+                cve_map[cve_id]['fixed_versions'].add(ver)
+
+    # Convert to list and count components
+    cve_list = []
+    for cve_id, data in cve_map.items():
+        # Format fixed versions
+        fixed_vers = sorted(data['fixed_versions'])
+        if len(fixed_vers) == 0:
+            fix_display = 'None'
+        elif len(fixed_vers) == 1:
+            fix_display = fixed_vers[0]
+        elif len(fixed_vers) <= 3:
+            fix_display = ', '.join(fixed_vers)
+        else:
+            fix_display = f"{fixed_vers[0]} (+{len(fixed_vers)-1} more)"
+
+        cve_list.append({
+            'cve_id': cve_id,
+            'severity': data['severity'],
+            'component_count': len(data['components']),
+            'components': list(data['components']),
+            'fixable': data['fixable'],
+            'fix_display': fix_display,
+            'sample_detail': data['sample_detail']  # For description/CVSS extraction
+        })
+
+    # Sort by component count (blast radius)
+    cve_list.sort(key=lambda x: x['component_count'], reverse=True)
+
+    return cve_list[:top_n]

--- a/scripts/cve_trends.py
+++ b/scripts/cve_trends.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Generate CVE trend analysis from historical scan data"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from rich.console import Console
+from rich.table import Table
+from rich.panel import Panel
+
+console = Console()
+
+
+def load_history(history_file):
+    """Load scan history from JSON file"""
+    if not history_file.exists():
+        console.print(f"[red]History file not found: {history_file}[/red]")
+        console.print("[yellow]Run a scan first to generate history data[/yellow]")
+        sys.exit(1)
+
+    try:
+        with open(history_file, 'r') as f:
+            return json.load(f)
+    except Exception as e:
+        console.print(f"[red]Error loading history: {e}[/red]")
+        sys.exit(1)
+
+
+def calculate_trend_direction(current, previous):
+    """Calculate trend direction and status"""
+    if previous is None:
+        return "→", "🟡 New"
+
+    delta = current - previous
+    if delta > 0:
+        return f"+{delta}↑", "🔴 Worse"
+    elif delta < 0:
+        return f"{delta}↓", "🟢 Better"
+    else:
+        return "0→", "🟡 Same"
+
+
+def format_timestamp(timestamp_str):
+    """Format ISO timestamp to readable date"""
+    try:
+        dt = datetime.fromisoformat(timestamp_str.replace('Z', ''))
+        return dt.strftime('%Y-%m-%d')
+    except:
+        return timestamp_str
+
+
+def get_top_offenders(history, limit=10):
+    """Calculate top components by CVE count across all scans"""
+    component_totals = {}
+
+    for scan in history.get('scans', []):
+        breakdown = scan.get('summary', {}).get('component_breakdown', {})
+
+        for component, counts in breakdown.items():
+            if component not in component_totals:
+                component_totals[component] = {
+                    'CRITICAL': 0,
+                    'HIGH': 0,
+                    'total': 0
+                }
+
+            component_totals[component]['CRITICAL'] += counts.get('CRITICAL', 0)
+            component_totals[component]['HIGH'] += counts.get('HIGH', 0)
+            component_totals[component]['total'] += counts.get('total', 0)
+
+    # Sort by total CVEs
+    sorted_components = sorted(
+        component_totals.items(),
+        key=lambda x: x[1]['total'],
+        reverse=True
+    )
+
+    return sorted_components[:limit]
+
+
+def print_trend_summary(history, weeks=8):
+    """Print weekly trend summary table"""
+    scans = history.get('scans', [])[-weeks:]
+
+    if not scans:
+        console.print("[yellow]No scan data available[/yellow]")
+        return
+
+    release = history.get('release', 'Unknown')
+
+    # Header panel
+    period_start = format_timestamp(scans[0]['timestamp'])
+    period_end = format_timestamp(scans[-1]['timestamp'])
+
+    header = Panel(
+        f"[bold]CVE Trend Report - {release}[/bold]\n"
+        f"Period: Last {len(scans)} weeks ({period_start} to {period_end})",
+        border_style="cyan"
+    )
+    console.print(header)
+
+    # Trend summary table
+    console.print("\n📈 [bold]Trend Summary[/bold]")
+
+    table = Table(show_header=True, header_style="bold cyan")
+    table.add_column("Week", style="dim")
+    table.add_column("CRITICAL", justify="center")
+    table.add_column("HIGH", justify="center")
+    table.add_column("Change", justify="center")
+    table.add_column("Status")
+
+    previous_total = None
+
+    for scan in scans:
+        timestamp = format_timestamp(scan['timestamp'])
+        severity = scan.get('summary', {}).get('by_severity', {})
+
+        critical = severity.get('CRITICAL', 0)
+        high = severity.get('HIGH', 0)
+        current_total = critical + high
+
+        change_str, status = calculate_trend_direction(current_total, previous_total)
+
+        table.add_row(
+            timestamp,
+            str(critical),
+            str(high),
+            change_str,
+            status
+        )
+
+        previous_total = current_total
+
+    console.print(table)
+
+
+def print_new_cves(latest_scan):
+    """Print new CVEs from latest scan"""
+    new_cves = latest_scan.get('new_cves', [])
+
+    if not new_cves:
+        console.print("\n[green]✓ No new CVEs detected[/green]")
+        return
+
+    # Filter to CRITICAL and HIGH only
+    critical_high = [
+        cve for cve in new_cves
+        if cve.get('severity') in ['CRITICAL', 'HIGH']
+    ]
+
+    if not critical_high:
+        console.print(f"\n[dim]ℹ️  {len(new_cves)} new CVEs (none CRITICAL/HIGH)[/dim]")
+        return
+
+    console.print(f"\n🔍 [bold]New CVEs This Week ({len(critical_high)})[/bold]")
+
+    table = Table(show_header=True, header_style="bold yellow")
+    table.add_column("CVE ID", style="yellow")
+    table.add_column("Severity", justify="center")
+    table.add_column("Component", style="cyan")
+    table.add_column("Fixable", justify="center")
+
+    for cve in critical_high[:20]:  # Limit to 20 for display
+        fixable = "✓ Yes" if cve.get('fixable') else "✗ No"
+
+        table.add_row(
+            cve.get('cve_id', 'Unknown'),
+            cve.get('severity', 'UNKNOWN'),
+            cve.get('component', 'unknown')[:30],  # Truncate long component names
+            fixable
+        )
+
+    console.print(table)
+
+    if len(critical_high) > 20:
+        console.print(f"[dim]... and {len(critical_high) - 20} more[/dim]")
+
+
+def print_fixed_cves(latest_scan):
+    """Print fixed CVEs from latest scan"""
+    fixed_cves = latest_scan.get('fixed_cves', [])
+
+    if not fixed_cves:
+        return
+
+    console.print(f"\n✅ [bold]Fixed CVEs (Resolved since last scan)[/bold]")
+
+    for cve in fixed_cves[:10]:  # Limit to 10
+        cve_id = cve.get('cve_id', 'Unknown')
+        component = cve.get('component', 'unknown')
+        console.print(f"  • {cve_id} in {component}")
+
+    if len(fixed_cves) > 10:
+        console.print(f"[dim]  ... and {len(fixed_cves) - 10} more[/dim]")
+
+
+def print_top_offenders(history):
+    """Print top offending components"""
+    top = get_top_offenders(history, limit=10)
+
+    if not top:
+        return
+
+    console.print("\n🏆 [bold]Top Offenders (by CVE count over period)[/bold]")
+
+    for i, (component, counts) in enumerate(top, 1):
+        console.print(
+            f"  {i}. {component}: {counts['total']} total CVEs "
+            f"({counts['CRITICAL']} CRITICAL, {counts['HIGH']} HIGH)"
+        )
+
+
+def print_statistics(history):
+    """Print overall statistics"""
+    scans = history.get('scans', [])
+
+    if len(scans) < 2:
+        return
+
+    console.print("\n📊 [bold]Stats[/bold]")
+
+    # Calculate averages
+    total_critical = sum(
+        scan.get('summary', {}).get('by_severity', {}).get('CRITICAL', 0)
+        for scan in scans
+    )
+    total_high = sum(
+        scan.get('summary', {}).get('by_severity', {}).get('HIGH', 0)
+        for scan in scans
+    )
+
+    avg_critical = total_critical / len(scans)
+    avg_high = total_high / len(scans)
+
+    console.print(f"  • Total scans: {len(scans)}")
+    console.print(f"  • Avg CRITICAL per week: {avg_critical:.1f}")
+    console.print(f"  • Avg HIGH per week: {avg_high:.1f}")
+
+    # Compare first and last
+    if len(scans) >= 4:
+        first_half = scans[:len(scans)//2]
+        second_half = scans[len(scans)//2:]
+
+        first_avg = sum(
+            scan.get('summary', {}).get('by_severity', {}).get('CRITICAL', 0)
+            for scan in first_half
+        ) / len(first_half)
+
+        second_avg = sum(
+            scan.get('summary', {}).get('by_severity', {}).get('CRITICAL', 0)
+            for scan in second_half
+        ) / len(second_half)
+
+        if second_avg > first_avg:
+            trend_text = f"🔴 Worsening ({second_avg:.0f} vs {first_avg:.0f} in first half)"
+        elif second_avg < first_avg:
+            trend_text = f"🟢 Improving ({second_avg:.0f} vs {first_avg:.0f} in first half)"
+        else:
+            trend_text = "🟡 Stable"
+
+        console.print(f"  • Trending: {trend_text}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate CVE trend analysis')
+    parser.add_argument('--reports-dir', default='reports',
+                       help='Reports directory (default: reports)')
+    parser.add_argument('--release', required=True,
+                       help='Release name (e.g., release-2.17)')
+    parser.add_argument('--weeks', type=int, default=8,
+                       help='Number of weeks to show in trend (default: 8)')
+    parser.add_argument('--format', choices=['table', 'json'], default='table',
+                       help='Output format (default: table)')
+
+    args = parser.parse_args()
+
+    # Load history
+    history_file = Path(args.reports_dir) / 'trends' / f"{args.release}-history.json"
+    history = load_history(history_file)
+
+    scans = history.get('scans', [])
+
+    if not scans:
+        console.print("[yellow]No scan data available[/yellow]")
+        sys.exit(0)
+
+    if args.format == 'json':
+        # Output raw JSON
+        print(json.dumps(history, indent=2))
+        return
+
+    # Print formatted report
+    print_trend_summary(history, weeks=args.weeks)
+
+    # Latest scan details
+    latest_scan = scans[-1]
+
+    print_new_cves(latest_scan)
+    print_fixed_cves(latest_scan)
+    print_top_offenders(history)
+    print_statistics(history)
+
+    console.print()  # Blank line at end
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/cve_trends.py
+++ b/scripts/cve_trends.py
@@ -24,7 +24,7 @@ def load_history(history_file):
     try:
         with open(history_file, 'r') as f:
             return json.load(f)
-    except Exception as e:
+    except (OSError, json.JSONDecodeError) as e:
         console.print(f"[red]Error loading history: {e}[/red]")
         sys.exit(1)
 
@@ -48,7 +48,7 @@ def format_timestamp(timestamp_str):
     try:
         dt = datetime.fromisoformat(timestamp_str.replace('Z', ''))
         return dt.strftime('%Y-%m-%d')
-    except:
+    except (ValueError, AttributeError):
         return timestamp_str
 
 

--- a/scripts/generate_multi_release_dashboard.py
+++ b/scripts/generate_multi_release_dashboard.py
@@ -1,0 +1,1452 @@
+#!/usr/bin/env python3
+"""Generate multi-release CVE trend dashboard with tabs"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from rich.console import Console
+from load_extras_metadata import load_extras_metadata
+from analyze_cve_blast_radius import analyze_blast_radius
+from load_cve_descriptions import load_cve_descriptions
+
+console = Console()
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ACM CVE Trends - All Releases</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <style>
+        * {{
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }}
+
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: #f5f5f5;
+            color: #333;
+            line-height: 1.6;
+        }}
+
+        .header {{
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 20px;
+            text-align: center;
+        }}
+
+        .header h1 {{
+            font-size: 2em;
+            margin-bottom: 5px;
+        }}
+
+        .header .meta {{
+            opacity: 0.9;
+            font-size: 0.95em;
+        }}
+
+        .tabs {{
+            background: white;
+            padding: 0;
+            display: flex;
+            border-bottom: 2px solid #e1e4e8;
+            overflow-x: auto;
+        }}
+
+        .tab {{
+            padding: 15px 25px;
+            cursor: pointer;
+            border: none;
+            background: none;
+            font-size: 1em;
+            color: #666;
+            border-bottom: 3px solid transparent;
+            transition: all 0.3s;
+            white-space: nowrap;
+        }}
+
+        .tab:hover {{
+            background: #f6f8fa;
+            color: #333;
+        }}
+
+        .tab.active {{
+            color: #0366d6;
+            border-bottom-color: #0366d6;
+            font-weight: 600;
+        }}
+
+        .tab-content {{
+            display: none;
+            padding: 30px;
+            max-width: 1400px;
+            margin: 0 auto;
+        }}
+
+        .tab-content.active {{
+            display: block;
+        }}
+
+        .summary-cards {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-bottom: 40px;
+        }}
+
+        .summary-card {{
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 20px;
+            border-radius: 6px;
+            text-align: center;
+        }}
+
+        .summary-card.critical {{
+            background: linear-gradient(135deg, #d73a49 0%, #cb2431 100%);
+        }}
+
+        .summary-card.high {{
+            background: linear-gradient(135deg, #f66a0a 0%, #e36209 100%);
+        }}
+
+        .summary-card.trend {{
+            background: linear-gradient(135deg, #28a745 0%, #22863a 100%);
+        }}
+
+        .summary-card.trend.worsening {{
+            background: linear-gradient(135deg, #d73a49 0%, #cb2431 100%);
+        }}
+
+        .summary-card h3 {{
+            font-size: 2.5em;
+            font-weight: bold;
+            margin-bottom: 5px;
+        }}
+
+        .summary-card p {{
+            font-size: 0.9em;
+            opacity: 0.9;
+        }}
+
+        .charts-grid {{
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 30px;
+            margin-bottom: 40px;
+        }}
+
+        .chart-container {{
+            background: white;
+            padding: 20px;
+            border-radius: 6px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }}
+
+        .chart-container h2 {{
+            font-size: 1.2em;
+            margin-bottom: 15px;
+            color: #24292e;
+        }}
+
+        canvas {{
+            max-height: 300px;
+        }}
+
+        .component-table {{
+            width: 100%;
+            border-collapse: collapse;
+            background: white;
+            border-radius: 6px;
+            overflow: hidden;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }}
+
+        .component-table th,
+        .component-table td {{
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid #e1e4e8;
+        }}
+
+        .component-table th {{
+            background: #f6f8fa;
+            font-weight: 600;
+            color: #24292e;
+            cursor: pointer;
+            user-select: none;
+            position: relative;
+            padding-right: 25px;
+        }}
+
+        .component-table th:hover {{
+            background: #e1e4e8;
+        }}
+
+        .component-table th::after {{
+            content: '⇅';
+            position: absolute;
+            right: 8px;
+            opacity: 0.3;
+        }}
+
+        .component-table th.sort-asc::after {{
+            content: '▲';
+            opacity: 1;
+        }}
+
+        .component-table th.sort-desc::after {{
+            content: '▼';
+            opacity: 1;
+        }}
+
+        .component-table tr:hover {{
+            background: #f6f8fa;
+        }}
+
+        .severity-badge {{
+            display: inline-block;
+            padding: 3px 8px;
+            border-radius: 3px;
+            font-size: 0.85em;
+            font-weight: 600;
+        }}
+
+        .severity-critical {{
+            background: #d73a49;
+            color: white;
+        }}
+
+        .severity-high {{
+            background: #f66a0a;
+            color: white;
+        }}
+
+        .no-data {{
+            text-align: center;
+            padding: 60px 20px;
+            color: #666;
+        }}
+
+        .no-data h2 {{
+            font-size: 1.5em;
+            margin-bottom: 10px;
+        }}
+
+        .show-all-btn {{
+            margin: 15px 0 30px 0;
+            padding: 10px 20px;
+            background: #0366d6;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.95em;
+            font-weight: 600;
+        }}
+
+        .show-all-btn:hover {{
+            background: #0256c5;
+        }}
+
+        .component-row-hidden {{
+            display: none;
+        }}
+
+        .cve-tooltip {{
+            position: relative;
+            cursor: help;
+        }}
+
+        .cve-tooltip .tooltiptext {{
+            visibility: hidden;
+            width: 450px;
+            background-color: #24292e;
+            color: #fff;
+            text-align: left;
+            border-radius: 6px;
+            padding: 15px;
+            position: absolute;
+            z-index: 1000;
+            top: -10px;
+            left: 120%;
+            opacity: 0;
+            transition: opacity 0.3s;
+            font-size: 0.9em;
+            line-height: 1.5;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+        }}
+
+        .cve-tooltip .tooltiptext::after {{
+            content: "";
+            position: absolute;
+            top: 20px;
+            right: 100%;
+            margin-top: -5px;
+            border-width: 5px;
+            border-style: solid;
+            border-color: transparent #24292e transparent transparent;
+        }}
+
+        .cve-tooltip:hover .tooltiptext {{
+            visibility: visible;
+            opacity: 1;
+        }}
+
+        .tooltip-title {{
+            font-weight: bold;
+            margin-bottom: 8px;
+            color: #58a6ff;
+        }}
+
+        .tooltip-cvss {{
+            color: #f85149;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }}
+
+        /* Component drill-down modal */
+        .modal {{
+            display: none;
+            position: fixed;
+            z-index: 2000;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            overflow: auto;
+            background-color: rgba(0,0,0,0.6);
+        }}
+
+        .modal-content {{
+            background-color: #fefefe;
+            margin: 5% auto;
+            padding: 0;
+            border: 1px solid #888;
+            width: 90%;
+            max-width: 1000px;
+            border-radius: 8px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+            max-height: 85vh;
+            overflow-y: auto;
+        }}
+
+        .modal-header {{
+            padding: 20px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border-radius: 8px 8px 0 0;
+        }}
+
+        .modal-header h2 {{
+            margin: 0;
+            font-size: 1.5em;
+        }}
+
+        .modal-body {{
+            padding: 20px;
+        }}
+
+        .close {{
+            color: white;
+            float: right;
+            font-size: 28px;
+            font-weight: bold;
+            cursor: pointer;
+        }}
+
+        .close:hover,
+        .close:focus {{
+            color: #ddd;
+        }}
+
+        .component-link {{
+            cursor: pointer;
+            text-decoration: underline;
+            color: #0366d6;
+        }}
+
+        .component-link:hover {{
+            color: #0256c5;
+        }}
+
+        /* Compare All tab specific styles */
+        .comparison-grid {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+            margin-bottom: 40px;
+        }}
+
+        .release-card {{
+            background: white;
+            padding: 20px;
+            border-radius: 6px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }}
+
+        .release-card h3 {{
+            font-size: 1.3em;
+            margin-bottom: 15px;
+            color: #24292e;
+        }}
+
+        .release-card .stat {{
+            display: flex;
+            justify-content: space-between;
+            padding: 8px 0;
+            border-bottom: 1px solid #e1e4e8;
+        }}
+
+        .release-card .stat:last-child {{
+            border-bottom: none;
+        }}
+
+        @media (max-width: 768px) {{
+            .charts-grid {{
+                grid-template-columns: 1fr;
+            }}
+            .comparison-grid {{
+                grid-template-columns: 1fr;
+            }}
+        }}
+    </style>
+</head>
+<body>
+    <div class="header">
+        <h1>🔒 ACM CVE Trend Dashboard</h1>
+        <p class="meta">Multi-Release Analysis | Updated: {timestamp}</p>
+    </div>
+
+    <div class="tabs">
+        <button class="tab active" onclick="openTab(event, 'compare-all')">📊 Compare All</button>
+        {tab_buttons}
+    </div>
+
+    <div id="compare-all" class="tab-content active">
+        <h2 style="margin-bottom: 20px; font-size: 1.8em;">Release Comparison</h2>
+        <div class="comparison-grid">
+            {comparison_cards}
+        </div>
+
+        <div class="chart-container" style="margin-bottom: 30px;">
+            <h2>All Releases - Latest CVE Counts</h2>
+            <canvas id="compareChart"></canvas>
+        </div>
+    </div>
+
+    {tab_contents}
+
+    <!-- Component CVE Detail Modal -->
+    <div id="cveModal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <span class="close" onclick="closeModal()">&times;</span>
+                <h2 id="modalTitle">Component CVEs</h2>
+            </div>
+            <div class="modal-body">
+                <div id="modalContent"></div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        {chart_data_js}
+
+        {component_cve_data_js}
+
+        function openTab(evt, tabName) {{
+            var i, tabcontent, tablinks;
+            tabcontent = document.getElementsByClassName("tab-content");
+            for (i = 0; i < tabcontent.length; i++) {{
+                tabcontent[i].className = tabcontent[i].className.replace(" active", "");
+            }}
+            tablinks = document.getElementsByClassName("tab");
+            for (i = 0; i < tablinks.length; i++) {{
+                tablinks[i].className = tablinks[i].className.replace(" active", "");
+            }}
+            document.getElementById(tabName).className += " active";
+            evt.currentTarget.className += " active";
+        }}
+
+        function sortTable(tabId, columnIndex, type) {{
+            const table = document.getElementById('componentTable-' + tabId);
+            const tbody = table.querySelector('tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+            const header = table.querySelectorAll('th')[columnIndex];
+
+            // Determine sort direction
+            const currentSort = header.classList.contains('sort-asc') ? 'asc' :
+                               header.classList.contains('sort-desc') ? 'desc' : 'none';
+            const newSort = currentSort === 'asc' ? 'desc' : 'asc';
+
+            // Remove all sort classes
+            table.querySelectorAll('th').forEach(th => {{
+                th.classList.remove('sort-asc', 'sort-desc');
+            }});
+
+            // Add new sort class
+            header.classList.add('sort-' + newSort);
+
+            // Sort rows
+            rows.sort((a, b) => {{
+                let aVal, bVal;
+
+                if (type === 'number') {{
+                    // Use data attributes for numeric sorting
+                    const dataAttr = ['component', 'critical', 'high', 'total'][columnIndex];
+                    aVal = parseInt(a.dataset[dataAttr] || 0);
+                    bVal = parseInt(b.dataset[dataAttr] || 0);
+                }} else {{
+                    // Text sorting
+                    aVal = a.cells[columnIndex].textContent.trim().toLowerCase();
+                    bVal = b.cells[columnIndex].textContent.trim().toLowerCase();
+                }}
+
+                if (newSort === 'asc') {{
+                    return aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
+                }} else {{
+                    return aVal < bVal ? 1 : aVal > bVal ? -1 : 0;
+                }}
+            }});
+
+            // Re-append sorted rows
+            rows.forEach(row => tbody.appendChild(row));
+        }}
+
+        function sortExternalTable(tabId, columnIndex, type) {{
+            const table = document.getElementById('externalTable-' + tabId);
+            const tbody = table.querySelector('tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+            const header = table.querySelectorAll('th')[columnIndex];
+
+            // Determine sort direction
+            const currentSort = header.classList.contains('sort-asc') ? 'asc' :
+                               header.classList.contains('sort-desc') ? 'desc' : 'none';
+            const newSort = currentSort === 'asc' ? 'desc' : 'asc';
+
+            // Remove all sort classes
+            table.querySelectorAll('th').forEach(th => {{
+                th.classList.remove('sort-asc', 'sort-desc');
+            }});
+
+            // Add new sort class
+            header.classList.add('sort-' + newSort);
+
+            // Sort rows
+            rows.sort((a, b) => {{
+                let aVal, bVal;
+
+                if (type === 'number') {{
+                    const dataAttr = ['component', 'critical', 'high', 'total'][columnIndex];
+                    aVal = parseInt(a.dataset[dataAttr] || 0);
+                    bVal = parseInt(b.dataset[dataAttr] || 0);
+                }} else {{
+                    aVal = a.cells[columnIndex].textContent.trim().toLowerCase();
+                    bVal = b.cells[columnIndex].textContent.trim().toLowerCase();
+                }}
+
+                if (newSort === 'asc') {{
+                    return aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
+                }} else {{
+                    return aVal < bVal ? 1 : aVal > bVal ? -1 : 0;
+                }}
+            }});
+
+            // Re-append sorted rows
+            rows.forEach(row => tbody.appendChild(row));
+        }}
+
+        function sortFixedTable(tabId, columnIndex) {{
+            const table = document.getElementById('fixedTable-' + tabId);
+            const tbody = table.querySelector('tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+            const header = table.querySelectorAll('th')[columnIndex];
+
+            // Determine sort direction
+            const currentSort = header.classList.contains('sort-asc') ? 'asc' :
+                               header.classList.contains('sort-desc') ? 'desc' : 'none';
+            const newSort = currentSort === 'asc' ? 'desc' : 'asc';
+
+            // Remove all sort classes
+            table.querySelectorAll('th').forEach(th => {{
+                th.classList.remove('sort-asc', 'sort-desc');
+            }});
+
+            // Add new sort class
+            header.classList.add('sort-' + newSort);
+
+            // Sort rows
+            rows.sort((a, b) => {{
+                const dataAttr = columnIndex === 0 ? 'cve' : 'component';
+                const aVal = a.dataset[dataAttr].toLowerCase();
+                const bVal = b.dataset[dataAttr].toLowerCase();
+
+                if (newSort === 'asc') {{
+                    return aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
+                }} else {{
+                    return aVal < bVal ? 1 : aVal > bVal ? -1 : 0;
+                }}
+            }});
+
+            // Re-append sorted rows
+            rows.forEach(row => tbody.appendChild(row));
+        }}
+
+        function sortBlastTable(tabId, columnIndex, type) {{
+            const table = document.getElementById('blastTable-' + tabId);
+            const tbody = table.querySelector('tbody');
+            const rows = Array.from(tbody.querySelectorAll('tr'));
+            const header = table.querySelectorAll('th')[columnIndex];
+
+            // Determine sort direction
+            const currentSort = header.classList.contains('sort-asc') ? 'asc' :
+                               header.classList.contains('sort-desc') ? 'desc' : 'none';
+            const newSort = currentSort === 'asc' ? 'desc' : 'asc';
+
+            // Remove all sort classes
+            table.querySelectorAll('th').forEach(th => {{
+                th.classList.remove('sort-asc', 'sort-desc');
+            }});
+
+            // Add new sort class
+            header.classList.add('sort-' + newSort);
+
+            // Sort rows
+            rows.sort((a, b) => {{
+                let aVal, bVal;
+
+                if (type === 'number') {{
+                    const dataAttr = ['cve', 'severity', 'cvss', 'count', '', '', 'fixable'][columnIndex];
+                    aVal = parseFloat(a.dataset[dataAttr] || 0);
+                    bVal = parseFloat(b.dataset[dataAttr] || 0);
+                }} else {{
+                    aVal = a.cells[columnIndex].textContent.trim().toLowerCase();
+                    bVal = b.cells[columnIndex].textContent.trim().toLowerCase();
+                }}
+
+                if (newSort === 'asc') {{
+                    return aVal > bVal ? 1 : aVal < bVal ? -1 : 0;
+                }} else {{
+                    return aVal < bVal ? 1 : aVal > bVal ? -1 : 0;
+                }}
+            }});
+
+            // Re-append sorted rows
+            rows.forEach(row => tbody.appendChild(row));
+        }}
+
+        function closeModal() {{
+            document.getElementById('cveModal').style.display = 'none';
+        }}
+
+        function showComponentCVEs(component, tabId) {{
+            const modal = document.getElementById('cveModal');
+            const title = document.getElementById('modalTitle');
+            const content = document.getElementById('modalContent');
+
+            title.textContent = `CVEs for ${{component}}`;
+
+            // Get CVE data for this component
+            const componentData = window.componentCVEData[tabId][component];
+
+            if (!componentData || componentData.length === 0) {{
+                content.innerHTML = '<p>No CVE data available for this component.</p>';
+                modal.style.display = 'block';
+                return;
+            }}
+
+            // Build CVE table
+            let html = `
+                <p><strong>${{componentData.length}} CVEs found</strong></p>
+                <table class="component-table">
+                    <thead>
+                        <tr>
+                            <th>CVE ID</th>
+                            <th>Severity</th>
+                            <th>CVSS</th>
+                            <th>Description</th>
+                            <th>Fix Available</th>
+                        </tr>
+                    </thead>
+                    <tbody>`;
+
+            componentData.forEach(cve => {{
+                const cvssDisplay = cve.cvss_score ? cve.cvss_score.toFixed(1) : '—';
+                const cvssColor = cve.cvss_score >= 9 ? '#d73a49' : cve.cvss_score >= 7 ? '#f66a0a' : '#666';
+                const severityClass = 'severity-' + cve.severity.toLowerCase();
+                const description = cve.description.substring(0, 150) + (cve.description.length > 150 ? '...' : '');
+
+                let cveLink;
+                if (cve.cve_id.startsWith('CVE-')) {{
+                    cveLink = `<a href="https://nvd.nist.gov/vuln/detail/${{cve.cve_id}}" target="_blank"><code>${{cve.cve_id}}</code></a>`;
+                }} else if (cve.cve_id.startsWith('GO-')) {{
+                    cveLink = `<a href="https://pkg.go.dev/vuln/${{cve.cve_id}}" target="_blank"><code>${{cve.cve_id}}</code></a>`;
+                }} else {{
+                    cveLink = `<code>${{cve.cve_id}}</code>`;
+                }}
+
+                html += `
+                    <tr>
+                        <td>${{cveLink}}</td>
+                        <td><span class="severity-badge ${{severityClass}}">${{cve.severity}}</span></td>
+                        <td style="text-align: center; color: ${{cvssColor}}; font-weight: 700;">${{cvssDisplay}}</td>
+                        <td style="font-size: 0.9em;">${{description}}</td>
+                        <td style="text-align: center; font-size: 0.9em;">${{cve.fix_display}}</td>
+                    </tr>`;
+            }});
+
+            html += `
+                    </tbody>
+                </table>`;
+
+            content.innerHTML = html;
+            modal.style.display = 'block';
+        }}
+
+        // Close modal when clicking outside
+        window.onclick = function(event) {{
+            const modal = document.getElementById('cveModal');
+            if (event.target == modal) {{
+                modal.style.display = 'none';
+            }}
+        }}
+
+        function toggleShowAll(tabId, tableType) {{
+            const tableId = tableType === 'internal' ? 'componentTable-' + tabId : 'externalTable-' + tabId;
+            const table = document.getElementById(tableId);
+            const hiddenRows = table.querySelectorAll('.component-row-hidden');
+            const btn = event.target;
+
+            if (hiddenRows.length > 0 && hiddenRows[0].style.display === 'none' || !hiddenRows[0].style.display) {{
+                // Show all
+                hiddenRows.forEach(row => row.style.display = 'table-row');
+                btn.textContent = btn.textContent.replace('Show All', 'Show Top 15');
+            }} else {{
+                // Hide extras
+                hiddenRows.forEach(row => row.style.display = 'none');
+                const total = btn.textContent.match(/\\d+/)[0];
+                btn.textContent = `Show All ${{tableType === 'internal' ? 'Internal' : 'External'}} (${{total}} total)`;
+            }}
+        }}
+
+        // Comparison chart
+        if (compareData) {{
+            const compareCtx = document.getElementById('compareChart').getContext('2d');
+            new Chart(compareCtx, {{
+                type: 'bar',
+                data: {{
+                    labels: compareData.labels,
+                    datasets: [
+                        {{
+                            label: 'CRITICAL',
+                            data: compareData.critical,
+                            backgroundColor: '#d73a49'
+                        }},
+                        {{
+                            label: 'HIGH',
+                            data: compareData.high,
+                            backgroundColor: '#f66a0a'
+                        }}
+                    ]
+                }},
+                options: {{
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    plugins: {{
+                        legend: {{
+                            position: 'bottom'
+                        }}
+                    }},
+                    scales: {{
+                        x: {{
+                            stacked: true
+                        }},
+                        y: {{
+                            stacked: true,
+                            beginAtZero: true
+                        }}
+                    }}
+                }}
+            }});
+        }}
+
+        // Individual release charts
+        {individual_charts_js}
+    </script>
+</body>
+</html>
+"""
+
+
+def format_timestamp(timestamp_str):
+    """Format ISO timestamp"""
+    try:
+        dt = datetime.fromisoformat(timestamp_str.replace('Z', ''))
+        return dt.strftime('%Y-%m-%d %H:%M UTC')
+    except:
+        return timestamp_str
+
+
+def format_date_short(timestamp_str):
+    """Format ISO timestamp to short date"""
+    try:
+        dt = datetime.fromisoformat(timestamp_str.replace('Z', ''))
+        return dt.strftime('%m/%d')
+    except:
+        return timestamp_str
+
+
+def load_release_history(trends_dir, release):
+    """Load history file for a release"""
+    history_file = trends_dir / f"{release}-history.json"
+
+    if not history_file.exists():
+        return None
+
+    try:
+        with open(history_file, 'r') as f:
+            return json.load(f)
+    except:
+        return None
+
+
+def get_version_from_reports(release):
+    """Map release-X.Y to version from reports/{version}/ directory"""
+    import re
+    from pathlib import Path
+
+    # Extract X.Y from release-X.Y
+    match = re.search(r'release-(\d+\.\d+)', release)
+    if not match:
+        return release.replace('release-', '')
+
+    major_minor = match.group(1)
+
+    # Find matching version directory in reports/ (e.g., reports/2.15.0/)
+    reports_path = Path('reports')
+    if not reports_path.exists():
+        return major_minor
+
+    # Find all matching version directories
+    matching = []
+    for item in reports_path.iterdir():
+        if item.is_dir() and item.name.startswith(major_minor):
+            # Verify it has json/ subdirectory (valid scan)
+            if (item / 'json').exists():
+                matching.append(item.name)
+
+    if not matching:
+        return major_minor
+
+    # Sort by version and get latest
+    matching.sort(key=lambda v: [int(x) for x in v.split('.')])
+    return matching[-1]
+
+
+def generate_tab_button(release, is_active=False):
+    """Generate tab button HTML"""
+    tab_id = release.replace('.', '').replace('-', '')  # release-2.17 -> release217
+    display_name = get_version_from_reports(release)
+    active_class = ' active' if is_active else ''
+    return f'<button class="tab{active_class}" onclick="openTab(event, \'{tab_id}\')">{display_name}</button>'
+
+
+def generate_component_cve_data_js(releases, cve_descriptions):
+    """Generate JavaScript data mapping components to their CVEs"""
+    component_data = {}
+
+    for release, history in releases.items():
+        tab_id = release.replace('.', '').replace('-', '')
+        scans = history.get('scans', [])
+
+        if not scans:
+            continue
+
+        latest_scan = scans[-1]
+        cve_details = latest_scan.get('summary', {}).get('cve_details', [])
+
+        # Group CVEs by component
+        comp_cve_map = {}
+        for detail in cve_details:
+            component = detail.get('component')
+            cve_id = detail.get('cve_id')
+            severity = detail.get('severity', 'UNKNOWN')
+
+            desc_data = cve_descriptions.get(cve_id, {})
+            cvss_score = desc_data.get('cvss_score')
+            description = desc_data.get('description', 'No description available')
+
+            fixed_versions = detail.get('fixed_versions', [])
+            if len(fixed_versions) == 0:
+                fix_display = 'None'
+            elif len(fixed_versions) == 1:
+                fix_display = fixed_versions[0]
+            else:
+                fix_display = f"{fixed_versions[0]} (+{len(fixed_versions)-1} more)"
+
+            if component not in comp_cve_map:
+                comp_cve_map[component] = []
+
+            comp_cve_map[component].append({
+                'cve_id': cve_id,
+                'severity': severity,
+                'cvss_score': cvss_score,
+                'description': description,
+                'fix_display': fix_display
+            })
+
+        component_data[tab_id] = comp_cve_map
+
+    return f"window.componentCVEData = {json.dumps(component_data)};"
+
+
+def generate_release_tab_content(release, history, extras_metadata=None):
+    """Generate tab content for a single release"""
+    tab_id = release.replace('.', '').replace('-', '')  # release-2.17 -> release217
+
+    scans = history.get('scans', [])
+
+    if not scans:
+        return f"""
+    <div id="{tab_id}" class="tab-content">
+        <div class="no-data">
+            <h2>No data available for {release}</h2>
+            <p>Run scans to populate trend data</p>
+        </div>
+    </div>"""
+
+    latest_scan = scans[-1]
+    latest_severity = latest_scan.get('summary', {}).get('by_severity', {})
+
+    # Calculate trend
+    trend_indicator = "—"
+    trend_class = "trend"
+    if len(scans) >= 2:
+        latest_total = latest_severity.get('CRITICAL', 0) + latest_severity.get('HIGH', 0)
+        previous_total = scans[-2].get('summary', {}).get('by_severity', {}).get('CRITICAL', 0) + \
+                        scans[-2].get('summary', {}).get('by_severity', {}).get('HIGH', 0)
+        delta = latest_total - previous_total
+        if delta > 0:
+            trend_indicator = f"+{delta}"
+            trend_class = "trend worsening"
+        elif delta < 0:
+            trend_indicator = str(delta)
+        else:
+            trend_indicator = "0"
+
+    # Get top components and separate internal vs external
+    component_breakdown = latest_scan.get('summary', {}).get('component_breakdown', {})
+
+    internal_components = []
+    external_components = []
+
+    for component, counts in component_breakdown.items():
+        has_git_link = extras_metadata and component in extras_metadata and extras_metadata[component].get('git_url')
+
+        if has_git_link:
+            internal_components.append((component, counts))
+        else:
+            external_components.append((component, counts))
+
+    # Sort both by total CVEs
+    internal_components.sort(key=lambda x: x[1].get('total', 0), reverse=True)
+    external_components.sort(key=lambda x: x[1].get('total', 0), reverse=True)
+
+    internal_rows = []
+    for i, (component, counts) in enumerate(internal_components):
+        critical = counts.get('CRITICAL', 0)
+        high = counts.get('HIGH', 0)
+        total = counts.get('total', 0)
+
+        # Get git metadata and make clickable for CVE drill-down
+        if extras_metadata and component in extras_metadata:
+            meta = extras_metadata[component]
+            if meta.get('commit_url'):
+                commit_short = meta['git_revision'][:7] if meta.get('git_revision') else ''
+                component_display = f'<span class="component-link" onclick="showComponentCVEs(\'{component}\', \'{tab_id}\')">{component}</span> <a href="{meta["commit_url"]}" target="_blank" style="text-decoration: none; color: #666; font-size: 0.85em;">({commit_short})</a>'
+            else:
+                component_display = f'<span class="component-link" onclick="showComponentCVEs(\'{component}\', \'{tab_id}\')">{component}</span>'
+        else:
+            component_display = f'<span class="component-link" onclick="showComponentCVEs(\'{component}\', \'{tab_id}\')">{component}</span>'
+
+        # Hide rows beyond top 15 by default
+        hidden_class = ' class="component-row-hidden"' if i >= 15 else ''
+
+        internal_rows.append(f"""
+                <tr{hidden_class} data-component="{component}" data-critical="{critical}" data-high="{high}" data-total="{total}">
+                    <td>{component_display}</td>
+                    <td style="text-align: center;"><span class="severity-badge severity-critical">{critical}</span></td>
+                    <td style="text-align: center;"><span class="severity-badge severity-high">{high}</span></td>
+                    <td style="text-align: center;">{total}</td>
+                </tr>""")
+
+    external_rows = []
+    for i, (component, counts) in enumerate(external_components):
+        critical = counts.get('CRITICAL', 0)
+        high = counts.get('HIGH', 0)
+        total = counts.get('total', 0)
+
+        # Hide rows beyond top 15 by default
+        hidden_class = ' class="component-row-hidden"' if i >= 15 else ''
+
+        external_rows.append(f"""
+                <tr{hidden_class} data-component="{component}" data-critical="{critical}" data-high="{high}" data-total="{total}">
+                    <td><span class="component-link" onclick="showComponentCVEs('{component}', '{tab_id}')">{component}</span> <span style="color: #666; font-size: 0.85em;">(upstream)</span></td>
+                    <td style="text-align: center;"><span class="severity-badge severity-critical">{critical}</span></td>
+                    <td style="text-align: center;"><span class="severity-badge severity-high">{high}</span></td>
+                    <td style="text-align: center;">{total}</td>
+                </tr>""")
+
+    return f"""
+    <div id="{tab_id}" class="tab-content">
+        <div class="summary-cards">
+            <div class="summary-card critical">
+                <h3>{latest_severity.get('CRITICAL', 0)}</h3>
+                <p>CRITICAL (instances)</p>
+            </div>
+            <div class="summary-card high">
+                <h3>{latest_severity.get('HIGH', 0)}</h3>
+                <p>HIGH (instances)</p>
+            </div>
+            <div class="summary-card">
+                <h3>{latest_scan.get('summary', {}).get('total_cves', 0)}</h3>
+                <p>Unique CVEs</p>
+                <p style="font-size: 0.8em; margin-top: 5px;">({latest_scan.get('summary', {}).get('total_matches', 0)} instances)</p>
+            </div>
+            <div class="summary-card {trend_class}">
+                <h3>{trend_indicator}</h3>
+                <p>Week-over-Week</p>
+            </div>
+        </div>
+
+        <div class="charts-grid">
+            <div class="chart-container">
+                <h2>📈 CVE Trend Over Time</h2>
+                <canvas id="trendChart-{tab_id}"></canvas>
+            </div>
+            <div class="chart-container">
+                <h2>🔄 New vs Fixed CVEs</h2>
+                <canvas id="deltaChart-{tab_id}"></canvas>
+            </div>
+        </div>
+
+        {generate_blast_radius_section_multi(latest_scan, tab_id, extras_metadata.get('cve_descriptions', {}))}
+
+        <h2 style="margin-bottom: 15px;">🏢 Internal Components (stolostron)</h2>
+        <table class="component-table" id="componentTable-{tab_id}">
+            <thead>
+                <tr>
+                    <th onclick="sortTable('{tab_id}', 0, 'string')">Component</th>
+                    <th style="text-align: center;" onclick="sortTable('{tab_id}', 1, 'number')">CRITICAL</th>
+                    <th style="text-align: center;" onclick="sortTable('{tab_id}', 2, 'number')">HIGH</th>
+                    <th style="text-align: center;" onclick="sortTable('{tab_id}', 3, 'number')">Total CVEs</th>
+                </tr>
+            </thead>
+            <tbody>
+                {''.join(internal_rows)}
+            </tbody>
+        </table>
+        {'<button class="show-all-btn" onclick="toggleShowAll(\'' + tab_id + '\', \'internal\')">Show All Internal (' + str(len(internal_components)) + ' total)</button>' if len(internal_components) > 15 else ''}
+
+        <h2 style="margin: 40px 0 15px 0;">🌐 External/Upstream Components</h2>
+        <table class="component-table" id="externalTable-{tab_id}">
+            <thead>
+                <tr>
+                    <th onclick="sortExternalTable('{tab_id}', 0, 'string')">Component</th>
+                    <th style="text-align: center;" onclick="sortExternalTable('{tab_id}', 1, 'number')">CRITICAL</th>
+                    <th style="text-align: center;" onclick="sortExternalTable('{tab_id}', 2, 'number')">HIGH</th>
+                    <th style="text-align: center;" onclick="sortExternalTable('{tab_id}', 3, 'number')">Total CVEs</th>
+                </tr>
+            </thead>
+            <tbody>
+                {''.join(external_rows)}
+            </tbody>
+        </table>
+        {'<button class="show-all-btn" onclick="toggleShowAll(\'' + tab_id + '\', \'external\')">Show All External (' + str(len(external_components)) + ' total)</button>' if len(external_components) > 15 else ''}
+
+        {generate_fixed_cves_section(latest_scan, tab_id)}
+    </div>"""
+
+
+def generate_blast_radius_section_multi(latest_scan, tab_id, cve_descriptions=None):
+    """Generate blast radius analysis table for multi-release"""
+    blast_radius_data = analyze_blast_radius(latest_scan, top_n=10)
+
+    if not blast_radius_data:
+        return ''
+
+    if cve_descriptions is None:
+        cve_descriptions = {}
+
+    rows = []
+    for cve in blast_radius_data:
+        severity_class = 'severity-' + cve.get('severity', 'unknown').lower()
+        fixable = '✓' if cve.get('fixable') else '✗'
+        fixable_color = '#28a745' if cve.get('fixable') else '#666'
+
+        # Get first 3 affected components
+        components = cve.get('components', [])[:3]
+        component_preview = ', '.join(components)
+        if cve.get('component_count', 0) > 3:
+            component_preview += f" +{cve.get('component_count') - 3} more"
+
+        severity_order = {'CRITICAL': 4, 'HIGH': 3, 'MEDIUM': 2, 'LOW': 1, 'UNKNOWN': 0}
+        severity_value = severity_order.get(cve.get('severity', 'UNKNOWN'), 0)
+
+        # Generate CVE link with tooltip
+        cve_id = cve.get('cve_id', 'Unknown')
+
+        # Get description and CVSS
+        desc_data = cve_descriptions.get(cve_id, {})
+        description = desc_data.get('description', 'No description available')
+        cvss_score = desc_data.get('cvss_score')
+
+        # Truncate description if too long
+        if len(description) > 300:
+            description = description[:297] + '...'
+
+        # Build tooltip content
+        tooltip_content = f'<div class="tooltip-title">{cve_id}</div>'
+        if cvss_score:
+            tooltip_content += f'<div class="tooltip-cvss">CVSS: {cvss_score} ({cve.get("severity", "UNKNOWN")})</div>'
+        tooltip_content += f'<div>{description}</div>'
+
+        # Generate link with tooltip wrapper
+        if cve_id.startswith('CVE-'):
+            base_link = f'https://nvd.nist.gov/vuln/detail/{cve_id}'
+        elif cve_id.startswith('GO-'):
+            base_link = f'https://pkg.go.dev/vuln/{cve_id}'
+        else:
+            base_link = '#'
+
+        cve_link = f'''<div class="cve-tooltip">
+            <a href="{base_link}" target="_blank" style="text-decoration: none; color: #0366d6;"><code>{cve_id}</code></a>
+            <span class="tooltiptext">{tooltip_content}</span>
+        </div>'''
+
+        fix_available = cve.get('fix_display', 'None')
+
+        # CVSS score display and color
+        cvss_display = '—'
+        cvss_color = '#666'
+        cvss_value = 0
+        if cvss_score:
+            cvss_display = f'{cvss_score:.1f}'
+            cvss_value = cvss_score
+            if cvss_score >= 9.0:
+                cvss_color = '#d73a49'  # Critical
+            elif cvss_score >= 7.0:
+                cvss_color = '#f66a0a'  # High
+            elif cvss_score >= 4.0:
+                cvss_color = '#e36209'  # Medium
+            else:
+                cvss_color = '#666'     # Low
+
+        rows.append(f"""
+                <tr data-cve="{cve_id}" data-severity="{severity_value}" data-count="{cve.get('component_count', 0)}" data-cvss="{cvss_value}" data-fixable="{1 if cve.get('fixable') else 0}">
+                    <td>{cve_link}</td>
+                    <td><span class="severity-badge {severity_class}">{cve.get('severity', 'UNKNOWN')}</span></td>
+                    <td style="text-align: center;"><strong style="color: {cvss_color}; font-weight: 700;">{cvss_display}</strong></td>
+                    <td style="text-align: center;"><strong style="color: #d73a49;">{cve.get('component_count', 0)}</strong></td>
+                    <td style="font-size: 0.9em; color: #666;">{component_preview}</td>
+                    <td style="text-align: center; color: {fixable_color}; font-size: 0.9em;">{fix_available}</td>
+                    <td style="text-align: center; color: {fixable_color}; font-weight: bold;">{fixable}</td>
+                </tr>""")
+
+    return f"""
+        <h2 style="margin: 40px 0 15px 0;">💥 Highest Blast Radius (CVEs affecting most components)</h2>
+        <table class="component-table" id="blastTable-{tab_id}">
+            <thead>
+                <tr>
+                    <th onclick="sortBlastTable('{tab_id}', 0, 'string')">CVE ID</th>
+                    <th onclick="sortBlastTable('{tab_id}', 1, 'number')">Severity</th>
+                    <th style="text-align: center;" onclick="sortBlastTable('{tab_id}', 2, 'number')">CVSS</th>
+                    <th style="text-align: center;" onclick="sortBlastTable('{tab_id}', 3, 'number')">Components</th>
+                    <th>Affected Components (preview)</th>
+                    <th style="text-align: center;">Fix Available</th>
+                    <th style="text-align: center;" onclick="sortBlastTable('{tab_id}', 6, 'number')">Fixable</th>
+                </tr>
+            </thead>
+            <tbody>
+                {''.join(rows)}
+            </tbody>
+        </table>
+    """
+
+
+def generate_fixed_cves_section(latest_scan, tab_id):
+    """Generate fixed CVEs section for release tab"""
+    fixed_cves = latest_scan.get('fixed_cves', [])
+
+    if not fixed_cves:
+        return ''
+
+    rows = []
+    for cve in fixed_cves[:20]:
+        cve_id = cve.get('cve_id', 'Unknown')
+        component = cve.get('component', 'unknown')
+        rows.append(f"""
+                <tr style="background: #dcffe4;" data-cve="{cve_id}" data-component="{component}">
+                    <td><code>{cve_id}</code></td>
+                    <td><code>{component}</code></td>
+                </tr>""")
+
+    return f"""
+        <h2 style="margin: 40px 0 15px 0;">✅ Fixed CVEs (Resolved since last scan: {len(fixed_cves)})</h2>
+        <table class="component-table" id="fixedTable-{tab_id}">
+            <thead>
+                <tr>
+                    <th onclick="sortFixedTable('{tab_id}', 0)">CVE ID</th>
+                    <th onclick="sortFixedTable('{tab_id}', 1)">Component</th>
+                </tr>
+            </thead>
+            <tbody>
+                {''.join(rows)}
+            </tbody>
+        </table>
+    """
+
+
+def generate_comparison_card(release, history):
+    """Generate comparison card for a release"""
+    scans = history.get('scans', [])
+
+    if not scans:
+        return f"""
+        <div class="release-card">
+            <h3>{release}</h3>
+            <p style="color: #666;">No data available</p>
+        </div>"""
+
+    latest = scans[-1].get('summary', {}).get('by_severity', {})
+
+    # Calculate trend
+    trend = "—"
+    if len(scans) >= 2:
+        latest_total = latest.get('CRITICAL', 0) + latest.get('HIGH', 0)
+        previous_total = scans[-2].get('summary', {}).get('by_severity', {}).get('CRITICAL', 0) + \
+                        scans[-2].get('summary', {}).get('by_severity', {}).get('HIGH', 0)
+        delta = latest_total - previous_total
+        if delta > 0:
+            trend = f"<span style='color: #d73a49;'>+{delta} ↑</span>"
+        elif delta < 0:
+            trend = f"<span style='color: #28a745;'>{delta} ↓</span>"
+        else:
+            trend = "<span style='color: #666;'>0 →</span>"
+
+    return f"""
+        <div class="release-card">
+            <h3>{release}</h3>
+            <div class="stat">
+                <span>CRITICAL:</span>
+                <strong style="color: #d73a49;">{latest.get('CRITICAL', 0)}</strong>
+            </div>
+            <div class="stat">
+                <span>HIGH:</span>
+                <strong style="color: #f66a0a;">{latest.get('HIGH', 0)}</strong>
+            </div>
+            <div class="stat">
+                <span>Unique CVEs:</span>
+                <strong>{scans[-1].get('summary', {}).get('total_cves', 0)}</strong>
+            </div>
+            <div class="stat">
+                <span>Total instances:</span>
+                <strong style="color: #666;">{scans[-1].get('summary', {}).get('total_matches', 0)}</strong>
+            </div>
+            <div class="stat">
+                <span>Scans:</span>
+                <strong>{len(scans)}</strong>
+            </div>
+            <div class="stat">
+                <span>Trend:</span>
+                {trend}
+            </div>
+        </div>"""
+
+
+def generate_chart_data(release, history):
+    """Generate JavaScript chart data for a release"""
+    scans = history.get('scans', [])[-12:]  # Last 12 weeks
+    tab_id = release.replace('.', '').replace('-', '')  # release-2.17 -> release217
+
+    labels = [format_date_short(scan['timestamp']) for scan in scans]
+    critical = [scan.get('summary', {}).get('by_severity', {}).get('CRITICAL', 0) for scan in scans]
+    high = [scan.get('summary', {}).get('by_severity', {}).get('HIGH', 0) for scan in scans]
+    new_cves = [len(scan.get('new_cves', [])) for scan in scans]
+    fixed_cves = [len(scan.get('fixed_cves', [])) for scan in scans]
+
+    return f"""
+        // {release} charts
+        const trendCtx{tab_id} = document.getElementById('trendChart-{tab_id}');
+        if (trendCtx{tab_id}) {{
+            new Chart(trendCtx{tab_id}.getContext('2d'), {{
+                type: 'line',
+                data: {{
+                    labels: {json.dumps(labels)},
+                    datasets: [
+                        {{
+                            label: 'CRITICAL',
+                            data: {json.dumps(critical)},
+                            borderColor: '#d73a49',
+                            backgroundColor: 'rgba(215, 58, 73, 0.1)',
+                            tension: 0.3,
+                            fill: true
+                        }},
+                        {{
+                            label: 'HIGH',
+                            data: {json.dumps(high)},
+                            borderColor: '#f66a0a',
+                            backgroundColor: 'rgba(246, 106, 10, 0.1)',
+                            tension: 0.3,
+                            fill: true
+                        }}
+                    ]
+                }},
+                options: {{
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    plugins: {{ legend: {{ position: 'bottom' }} }},
+                    scales: {{ y: {{ beginAtZero: true }} }}
+                }}
+            }});
+        }}
+
+        const deltaCtx{tab_id} = document.getElementById('deltaChart-{tab_id}');
+        if (deltaCtx{tab_id}) {{
+            new Chart(deltaCtx{tab_id}.getContext('2d'), {{
+                type: 'bar',
+                data: {{
+                    labels: {json.dumps(labels)},
+                    datasets: [
+                        {{
+                            label: 'New CVEs',
+                            data: {json.dumps(new_cves)},
+                            backgroundColor: '#d73a49'
+                        }},
+                        {{
+                            label: 'Fixed CVEs',
+                            data: {json.dumps(fixed_cves)},
+                            backgroundColor: '#28a745'
+                        }}
+                    ]
+                }},
+                options: {{
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    plugins: {{ legend: {{ position: 'bottom' }} }},
+                    scales: {{ y: {{ beginAtZero: true }} }}
+                }}
+            }});
+        }}
+    """
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate multi-release CVE trend dashboard')
+    parser.add_argument('--reports-dir', default='reports',
+                       help='Reports directory (default: reports)')
+    parser.add_argument('--output',
+                       help='Output HTML file path (default: reports/trends/multi-release-dashboard.html)')
+
+    args = parser.parse_args()
+
+    trends_dir = Path(args.reports_dir) / 'trends'
+
+    if not trends_dir.exists():
+        console.print(f"[red]Trends directory not found: {trends_dir}[/red]")
+        sys.exit(1)
+
+    # Find all history files
+    history_files = list(trends_dir.glob('release-*-history.json'))
+
+    if not history_files:
+        console.print("[yellow]No release history files found[/yellow]")
+        sys.exit(0)
+
+    console.print(f"[cyan]Found {len(history_files)} releases[/cyan]")
+
+    # Load git metadata from extras
+    extras_metadata = load_extras_metadata()
+
+    # Load CVE descriptions
+    cve_descriptions = load_cve_descriptions(args.reports_dir)
+    extras_metadata['cve_descriptions'] = cve_descriptions
+
+    # Load all histories
+    releases = {}
+    for history_file in sorted(history_files):
+        release = history_file.stem.replace('-history', '')
+        history = load_release_history(trends_dir, release)
+        if history:
+            releases[release] = history
+            console.print(f"  • {release}: {len(history.get('scans', []))} scans")
+
+    if not releases:
+        console.print("[yellow]No valid history data found[/yellow]")
+        sys.exit(0)
+
+    # Generate HTML components
+    tab_buttons = '\n'.join([generate_tab_button(rel) for rel in sorted(releases.keys())])
+    tab_contents = '\n'.join([generate_release_tab_content(rel, hist, extras_metadata) for rel, hist in sorted(releases.items())])
+    comparison_cards = '\n'.join([generate_comparison_card(rel, hist) for rel, hist in sorted(releases.items())])
+
+    # Generate component CVE data for drill-down
+    component_cve_data_js = generate_component_cve_data_js(releases, cve_descriptions)
+
+    # Generate comparison chart data
+    compare_labels = []
+    compare_critical = []
+    compare_high = []
+
+    for release in sorted(releases.keys()):
+        history = releases[release]
+        scans = history.get('scans', [])
+        if scans:
+            compare_labels.append(release)
+            latest = scans[-1].get('summary', {}).get('by_severity', {})
+            compare_critical.append(latest.get('CRITICAL', 0))
+            compare_high.append(latest.get('HIGH', 0))
+
+    compare_data_js = f"const compareData = {json.dumps({'labels': compare_labels, 'critical': compare_critical, 'high': compare_high})};"
+
+    # Generate individual chart scripts
+    individual_charts = '\n'.join([generate_chart_data(rel, hist) for rel, hist in sorted(releases.items())])
+
+    # Generate final HTML
+    html = HTML_TEMPLATE.format(
+        timestamp=datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC'),
+        tab_buttons=tab_buttons,
+        tab_contents=tab_contents,
+        comparison_cards=comparison_cards,
+        chart_data_js=compare_data_js,
+        component_cve_data_js=component_cve_data_js,
+        individual_charts_js=individual_charts
+    )
+
+    # Determine output path
+    output_path = args.output
+    if not output_path:
+        output_path = trends_dir / 'multi-release-dashboard.html'
+    else:
+        output_path = Path(output_path)
+
+    # Write HTML
+    try:
+        with open(output_path, 'w') as f:
+            f.write(html)
+        console.print(f"[green]✓ Multi-release dashboard generated: {output_path}[/green]")
+    except Exception as e:
+        console.print(f"[red]Error writing HTML: {e}[/red]")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate_multi_release_dashboard.py
+++ b/scripts/generate_multi_release_dashboard.py
@@ -719,6 +719,17 @@ HTML_TEMPLATE = """<!DOCTYPE html>
             }}
         }}
 
+        // Attach click handlers to component links (prevents XSS from inline onclick)
+        document.addEventListener('DOMContentLoaded', function() {{
+            document.querySelectorAll('.component-link').forEach(link => {{
+                link.addEventListener('click', function() {{
+                    const component = this.getAttribute('data-component');
+                    const tabId = this.getAttribute('data-tab');
+                    showComponentCVEs(component, tabId);
+                }});
+            }});
+        }});
+
         function toggleShowAll(tabId, tableType) {{
             const tableId = tableType === 'internal' ? 'componentTable-' + tabId : 'externalTable-' + tabId;
             const table = document.getElementById(tableId);
@@ -846,8 +857,17 @@ def get_version_from_reports(release):
     if not matching:
         return major_minor
 
-    # Sort by version and get latest
-    matching.sort(key=lambda v: [int(x) for x in v.split('.')])
+    # Sort by version and get latest (handle non-numeric like 2.15.0-rc1)
+    def version_key(v):
+        import re
+        parts = []
+        for part in v.split('.'):
+            # Extract leading digits, default to 0
+            match = re.match(r'^(\d+)', part)
+            parts.append(int(match.group(1)) if match else 0)
+        return parts
+
+    matching.sort(key=version_key)
     return matching[-1]
 
 
@@ -966,16 +986,16 @@ def generate_release_tab_content(release, history, extras_metadata=None):
         high = counts.get('HIGH', 0)
         total = counts.get('total', 0)
 
-        # Get git metadata and make clickable for CVE drill-down
+        # Get git metadata and make clickable for CVE drill-down (use data attrs to avoid XSS)
         if extras_metadata and component in extras_metadata:
             meta = extras_metadata[component]
             if meta.get('commit_url'):
                 commit_short = meta['git_revision'][:7] if meta.get('git_revision') else ''
-                component_display = f'<span class="component-link" onclick="showComponentCVEs(\'{component}\', \'{tab_id}\')">{component}</span> <a href="{meta["commit_url"]}" target="_blank" style="text-decoration: none; color: #666; font-size: 0.85em;">({commit_short})</a>'
+                component_display = f'<span class="component-link" data-component="{component}" data-tab="{tab_id}">{component}</span> <a href="{meta["commit_url"]}" target="_blank" style="text-decoration: none; color: #666; font-size: 0.85em;">({commit_short})</a>'
             else:
-                component_display = f'<span class="component-link" onclick="showComponentCVEs(\'{component}\', \'{tab_id}\')">{component}</span>'
+                component_display = f'<span class="component-link" data-component="{component}" data-tab="{tab_id}">{component}</span>'
         else:
-            component_display = f'<span class="component-link" onclick="showComponentCVEs(\'{component}\', \'{tab_id}\')">{component}</span>'
+            component_display = f'<span class="component-link" data-component="{component}" data-tab="{tab_id}">{component}</span>'
 
         # Hide rows beyond top 15 by default
         hidden_class = ' class="component-row-hidden"' if i >= 15 else ''
@@ -999,7 +1019,7 @@ def generate_release_tab_content(release, history, extras_metadata=None):
 
         external_rows.append(f"""
                 <tr{hidden_class} data-component="{component}" data-critical="{critical}" data-high="{high}" data-total="{total}">
-                    <td><span class="component-link" onclick="showComponentCVEs('{component}', '{tab_id}')">{component}</span> <span style="color: #666; font-size: 0.85em;">(upstream)</span></td>
+                    <td><span class="component-link" data-component="{component}" data-tab="{tab_id}">{component}</span> <span style="color: #666; font-size: 0.85em;">(upstream)</span></td>
                     <td style="text-align: center;"><span class="severity-badge severity-critical">{critical}</span></td>
                     <td style="text-align: center;"><span class="severity-badge severity-high">{high}</span></td>
                     <td style="text-align: center;">{total}</td>

--- a/scripts/generate_multi_release_dashboard.py
+++ b/scripts/generate_multi_release_dashboard.py
@@ -4,7 +4,7 @@
 import argparse
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from rich.console import Console
@@ -802,7 +802,7 @@ def format_timestamp(timestamp_str):
     try:
         dt = datetime.fromisoformat(timestamp_str.replace('Z', ''))
         return dt.strftime('%Y-%m-%d %H:%M UTC')
-    except:
+    except (ValueError, AttributeError):
         return timestamp_str
 
 
@@ -811,7 +811,7 @@ def format_date_short(timestamp_str):
     try:
         dt = datetime.fromisoformat(timestamp_str.replace('Z', ''))
         return dt.strftime('%m/%d')
-    except:
+    except (ValueError, AttributeError):
         return timestamp_str
 
 
@@ -825,7 +825,7 @@ def load_release_history(trends_dir, release):
     try:
         with open(history_file, 'r') as f:
             return json.load(f)
-    except:
+    except (ValueError, AttributeError):
         return None
 
 
@@ -1442,7 +1442,7 @@ def main():
 
     # Generate final HTML
     html = HTML_TEMPLATE.format(
-        timestamp=datetime.utcnow().strftime('%Y-%m-%d %H:%M UTC'),
+        timestamp=datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC'),
         tab_buttons=tab_buttons,
         tab_contents=tab_contents,
         comparison_cards=comparison_cards,
@@ -1463,7 +1463,7 @@ def main():
         with open(output_path, 'w') as f:
             f.write(html)
         console.print(f"[green]✓ Multi-release dashboard generated: {output_path}[/green]")
-    except Exception as e:
+    except (OSError, PermissionError) as e:
         console.print(f"[red]Error writing HTML: {e}[/red]")
         sys.exit(1)
 

--- a/scripts/generate_trend_report.py
+++ b/scripts/generate_trend_report.py
@@ -374,7 +374,7 @@ def format_timestamp(timestamp_str):
     try:
         dt = datetime.fromisoformat(timestamp_str.replace('Z', ''))
         return dt.strftime('%Y-%m-%d %H:%M UTC')
-    except:
+    except (ValueError, AttributeError):
         return timestamp_str
 
 
@@ -383,7 +383,7 @@ def format_date_short(timestamp_str):
     try:
         dt = datetime.fromisoformat(timestamp_str.replace('Z', ''))
         return dt.strftime('%m/%d')
-    except:
+    except (ValueError, AttributeError):
         return timestamp_str
 
 
@@ -654,7 +654,7 @@ def main():
     try:
         with open(history_file, 'r') as f:
             history = json.load(f)
-    except Exception as e:
+    except (OSError, json.JSONDecodeError) as e:
         console.print(f"[red]Error loading history: {e}[/red]")
         sys.exit(1)
 
@@ -706,7 +706,7 @@ def main():
         with open(output_path, 'w') as f:
             f.write(html)
         console.print(f"[green]✓ Dashboard generated: {output_path}[/green]")
-    except Exception as e:
+    except (OSError, PermissionError) as e:
         console.print(f"[red]Error writing HTML: {e}[/red]")
         sys.exit(1)
 

--- a/scripts/generate_trend_report.py
+++ b/scripts/generate_trend_report.py
@@ -1,0 +1,715 @@
+#!/usr/bin/env python3
+"""Generate HTML dashboard from CVE trend data"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from rich.console import Console
+from load_extras_metadata import load_extras_metadata
+from analyze_cve_blast_radius import analyze_blast_radius
+
+console = Console()
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ACM CVE Trends - {release}</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <style>
+        * {{
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }}
+
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: #f5f5f5;
+            color: #333;
+            padding: 20px;
+            line-height: 1.6;
+        }}
+
+        .container {{
+            max-width: 1400px;
+            margin: 0 auto;
+            background: white;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }}
+
+        h1 {{
+            color: #d73a49;
+            margin-bottom: 10px;
+            font-size: 2em;
+        }}
+
+        .meta {{
+            color: #666;
+            margin-bottom: 30px;
+            font-size: 0.95em;
+        }}
+
+        .meta strong {{
+            color: #333;
+        }}
+
+        .charts-grid {{
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 30px;
+            margin-bottom: 40px;
+        }}
+
+        .chart-container {{
+            background: #fafafa;
+            padding: 20px;
+            border-radius: 6px;
+            border: 1px solid #e1e4e8;
+        }}
+
+        .chart-container h2 {{
+            font-size: 1.2em;
+            margin-bottom: 15px;
+            color: #24292e;
+        }}
+
+        canvas {{
+            max-height: 300px;
+        }}
+
+        .summary-cards {{
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-bottom: 40px;
+        }}
+
+        .summary-card {{
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 20px;
+            border-radius: 6px;
+            text-align: center;
+        }}
+
+        .summary-card.critical {{
+            background: linear-gradient(135deg, #d73a49 0%, #cb2431 100%);
+        }}
+
+        .summary-card.high {{
+            background: linear-gradient(135deg, #f66a0a 0%, #e36209 100%);
+        }}
+
+        .summary-card.trend {{
+            background: linear-gradient(135deg, #28a745 0%, #22863a 100%);
+        }}
+
+        .summary-card h3 {{
+            font-size: 2.5em;
+            font-weight: bold;
+            margin-bottom: 5px;
+        }}
+
+        .summary-card p {{
+            font-size: 0.9em;
+            opacity: 0.9;
+        }}
+
+        .component-table {{
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 40px;
+        }}
+
+        .component-table th,
+        .component-table td {{
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid #e1e4e8;
+        }}
+
+        .component-table th {{
+            background: #f6f8fa;
+            font-weight: 600;
+            color: #24292e;
+        }}
+
+        .component-table tr:hover {{
+            background: #f6f8fa;
+        }}
+
+        .status-red {{
+            background: #ffeef0;
+        }}
+
+        .status-yellow {{
+            background: #fffdef;
+        }}
+
+        .status-green {{
+            background: #dcffe4;
+        }}
+
+        .severity-badge {{
+            display: inline-block;
+            padding: 3px 8px;
+            border-radius: 3px;
+            font-size: 0.85em;
+            font-weight: 600;
+        }}
+
+        .severity-critical {{
+            background: #d73a49;
+            color: white;
+        }}
+
+        .severity-high {{
+            background: #f66a0a;
+            color: white;
+        }}
+
+        .timeline {{
+            margin-top: 40px;
+        }}
+
+        .timeline h2 {{
+            font-size: 1.5em;
+            margin-bottom: 20px;
+            color: #24292e;
+        }}
+
+        .timeline ul {{
+            list-style: none;
+            border-left: 2px solid #e1e4e8;
+            padding-left: 20px;
+        }}
+
+        .timeline li {{
+            margin-bottom: 15px;
+            position: relative;
+        }}
+
+        .timeline li::before {{
+            content: '';
+            position: absolute;
+            left: -26px;
+            top: 6px;
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            background: #0366d6;
+        }}
+
+        .timeline .date {{
+            font-weight: 600;
+            color: #0366d6;
+            margin-right: 10px;
+        }}
+
+        @media (max-width: 768px) {{
+            .charts-grid {{
+                grid-template-columns: 1fr;
+            }}
+        }}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🔒 ACM CVE Trend Dashboard</h1>
+        <p class="meta">Release: <strong>{release}</strong> | Updated: {last_updated} | Scans: {scan_count}</p>
+
+        <div class="summary-cards">
+            <div class="summary-card critical">
+                <h3>{latest_critical}</h3>
+                <p>CRITICAL (instances)</p>
+            </div>
+            <div class="summary-card high">
+                <h3>{latest_high}</h3>
+                <p>HIGH (instances)</p>
+            </div>
+            <div class="summary-card">
+                <h3>{total_cves}</h3>
+                <p>Unique CVEs</p>
+                <p style="font-size: 0.8em; margin-top: 5px; opacity: 0.9;">({total_instances} instances)</p>
+            </div>
+            <div class="summary-card trend">
+                <h3>{trend_indicator}</h3>
+                <p>Week-over-Week</p>
+            </div>
+        </div>
+
+        <div class="charts-grid">
+            <div class="chart-container">
+                <h2>📈 CVE Trend Over Time</h2>
+                <canvas id="trendChart"></canvas>
+            </div>
+            <div class="chart-container">
+                <h2>🔄 New vs Fixed CVEs</h2>
+                <canvas id="deltaChart"></canvas>
+            </div>
+        </div>
+
+        <h2 style="margin-bottom: 15px;">📊 Component Breakdown</h2>
+        <table class="component-table">
+            <thead>
+                <tr>
+                    <th>Component</th>
+                    <th style="text-align: center;">CRITICAL</th>
+                    <th style="text-align: center;">HIGH</th>
+                    <th style="text-align: center;">Total CVEs</th>
+                </tr>
+            </thead>
+            <tbody>
+                {component_rows}
+            </tbody>
+        </table>
+
+        {blast_radius_section}
+
+        {new_cves_section}
+
+        {fixed_cves_section}
+
+        <div class="timeline">
+            <h2>📅 Recent Activity</h2>
+            <ul>
+                {timeline_items}
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        {chart_data_js}
+
+        // Trend Chart
+        const trendCtx = document.getElementById('trendChart').getContext('2d');
+        new Chart(trendCtx, {{
+            type: 'line',
+            data: {{
+                labels: chartData.labels,
+                datasets: [
+                    {{
+                        label: 'CRITICAL',
+                        data: chartData.critical,
+                        borderColor: '#d73a49',
+                        backgroundColor: 'rgba(215, 58, 73, 0.1)',
+                        tension: 0.3,
+                        fill: true
+                    }},
+                    {{
+                        label: 'HIGH',
+                        data: chartData.high,
+                        borderColor: '#f66a0a',
+                        backgroundColor: 'rgba(246, 106, 10, 0.1)',
+                        tension: 0.3,
+                        fill: true
+                    }}
+                ]
+            }},
+            options: {{
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {{
+                    legend: {{
+                        position: 'bottom'
+                    }}
+                }},
+                scales: {{
+                    y: {{
+                        beginAtZero: true
+                    }}
+                }}
+            }}
+        }});
+
+        // Delta Chart
+        const deltaCtx = document.getElementById('deltaChart').getContext('2d');
+        new Chart(deltaCtx, {{
+            type: 'bar',
+            data: {{
+                labels: chartData.labels,
+                datasets: [
+                    {{
+                        label: 'New CVEs',
+                        data: chartData.newCves,
+                        backgroundColor: '#d73a49'
+                    }},
+                    {{
+                        label: 'Fixed CVEs',
+                        data: chartData.fixedCves,
+                        backgroundColor: '#28a745'
+                    }}
+                ]
+            }},
+            options: {{
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {{
+                    legend: {{
+                        position: 'bottom'
+                    }}
+                }},
+                scales: {{
+                    y: {{
+                        beginAtZero: true
+                    }}
+                }}
+            }}
+        }});
+    </script>
+</body>
+</html>
+"""
+
+
+def format_timestamp(timestamp_str):
+    """Format ISO timestamp to readable format"""
+    try:
+        dt = datetime.fromisoformat(timestamp_str.replace('Z', ''))
+        return dt.strftime('%Y-%m-%d %H:%M UTC')
+    except:
+        return timestamp_str
+
+
+def format_date_short(timestamp_str):
+    """Format ISO timestamp to short date"""
+    try:
+        dt = datetime.fromisoformat(timestamp_str.replace('Z', ''))
+        return dt.strftime('%m/%d')
+    except:
+        return timestamp_str
+
+
+def generate_chart_data(history):
+    """Generate JavaScript chart data"""
+    scans = history.get('scans', [])[-12:]  # Last 12 weeks
+
+    labels = [format_date_short(scan['timestamp']) for scan in scans]
+    critical = [
+        scan.get('summary', {}).get('by_severity', {}).get('CRITICAL', 0)
+        for scan in scans
+    ]
+    high = [
+        scan.get('summary', {}).get('by_severity', {}).get('HIGH', 0)
+        for scan in scans
+    ]
+    new_cves = [len(scan.get('new_cves', [])) for scan in scans]
+    fixed_cves = [len(scan.get('fixed_cves', [])) for scan in scans]
+
+    chart_data = {
+        'labels': labels,
+        'critical': critical,
+        'high': high,
+        'newCves': new_cves,
+        'fixedCves': fixed_cves
+    }
+
+    return f"const chartData = {json.dumps(chart_data)};"
+
+
+def generate_component_rows(latest_scan, extras_metadata=None):
+    """Generate HTML rows for component table"""
+    breakdown = latest_scan.get('summary', {}).get('component_breakdown', {})
+
+    # Sort by total CVEs
+    sorted_components = sorted(
+        breakdown.items(),
+        key=lambda x: x[1].get('total', 0),
+        reverse=True
+    )[:20]  # Top 20
+
+    rows = []
+    for component, counts in sorted_components:
+        critical = counts.get('CRITICAL', 0)
+        high = counts.get('HIGH', 0)
+        total = counts.get('total', 0)
+
+        # Determine row class
+        row_class = ''
+        if critical > 5:
+            row_class = 'status-red'
+        elif critical > 0 or high > 10:
+            row_class = 'status-yellow'
+
+        # Get git metadata
+        component_display = component
+        if extras_metadata and component in extras_metadata:
+            meta = extras_metadata[component]
+            if meta.get('commit_url'):
+                git_repo = meta['git_url'].split('/')[-1] if meta.get('git_url') else 'repo'
+                commit_short = meta['git_revision'][:7] if meta.get('git_revision') else ''
+                component_display = f'<a href="{meta["commit_url"]}" target="_blank" style="text-decoration: none; color: #0366d6;">{component}</a> <span style="color: #666; font-size: 0.85em;">({commit_short})</span>'
+
+        rows.append(f"""
+                <tr class="{row_class}">
+                    <td><code>{component_display}</code></td>
+                    <td style="text-align: center;"><span class="severity-badge severity-critical">{critical}</span></td>
+                    <td style="text-align: center;"><span class="severity-badge severity-high">{high}</span></td>
+                    <td style="text-align: center;">{total}</td>
+                </tr>""")
+
+    return '\n'.join(rows)
+
+
+def generate_new_cves_section(latest_scan):
+    """Generate HTML section for new CVEs"""
+    new_cves = latest_scan.get('new_cves', [])
+
+    # Filter CRITICAL and HIGH
+    critical_high = [
+        cve for cve in new_cves
+        if cve.get('severity') in ['CRITICAL', 'HIGH']
+    ]
+
+    if not critical_high:
+        return ''
+
+    rows = []
+    for cve in critical_high[:15]:  # Top 15
+        severity_class = 'severity-' + cve.get('severity', 'unknown').lower()
+        fixable = '✓ Yes' if cve.get('fixable') else '✗ No'
+
+        rows.append(f"""
+                <tr>
+                    <td><code>{cve.get('cve_id', 'Unknown')}</code></td>
+                    <td><span class="severity-badge {severity_class}">{cve.get('severity', 'UNKNOWN')}</span></td>
+                    <td><code>{cve.get('component', 'unknown')}</code></td>
+                    <td>{fixable}</td>
+                </tr>""")
+
+    return f"""
+        <h2 style="margin: 40px 0 15px 0;">🆕 New CVEs This Week ({len(critical_high)})</h2>
+        <table class="component-table">
+            <thead>
+                <tr>
+                    <th>CVE ID</th>
+                    <th>Severity</th>
+                    <th>Component</th>
+                    <th>Fixable</th>
+                </tr>
+            </thead>
+            <tbody>
+                {''.join(rows)}
+            </tbody>
+        </table>
+    """
+
+
+def generate_fixed_cves_section(latest_scan):
+    """Generate HTML section for fixed CVEs"""
+    fixed_cves = latest_scan.get('fixed_cves', [])
+
+    if not fixed_cves:
+        return ''
+
+    rows = []
+    for cve in fixed_cves[:20]:  # Top 20
+        rows.append(f"""
+                <tr style="background: #dcffe4;">
+                    <td><code>{cve.get('cve_id', 'Unknown')}</code></td>
+                    <td><code>{cve.get('component', 'unknown')}</code></td>
+                </tr>""")
+
+    return f"""
+        <h2 style="margin: 40px 0 15px 0;">✅ Fixed CVEs (Resolved since last scan: {len(fixed_cves)})</h2>
+        <table class="component-table">
+            <thead>
+                <tr>
+                    <th>CVE ID</th>
+                    <th>Component</th>
+                </tr>
+            </thead>
+            <tbody>
+                {''.join(rows)}
+            </tbody>
+        </table>
+    """
+
+
+def generate_blast_radius_section(latest_scan):
+    """Generate blast radius analysis table"""
+    blast_radius_data = analyze_blast_radius(latest_scan, top_n=10)
+
+    if not blast_radius_data:
+        return ''
+
+    rows = []
+    for cve in blast_radius_data:
+        severity_class = 'severity-' + cve.get('severity', 'unknown').lower()
+        fixable = '✓' if cve.get('fixable') else '✗'
+        fixable_color = '#28a745' if cve.get('fixable') else '#666'
+
+        # Get first 3 affected components
+        components = cve.get('components', [])[:3]
+        component_preview = ', '.join(components)
+        if cve.get('component_count', 0) > 3:
+            component_preview += f" +{cve.get('component_count') - 3} more"
+
+        # Generate CVE link
+        cve_id = cve.get('cve_id', 'Unknown')
+        if cve_id.startswith('CVE-'):
+            cve_link = f'<a href="https://nvd.nist.gov/vuln/detail/{cve_id}" target="_blank" style="text-decoration: none; color: #0366d6;"><code>{cve_id}</code></a>'
+        elif cve_id.startswith('GO-'):
+            cve_link = f'<a href="https://pkg.go.dev/vuln/{cve_id}" target="_blank" style="text-decoration: none; color: #0366d6;"><code>{cve_id}</code></a>'
+        else:
+            cve_link = f'<code>{cve_id}</code>'
+
+        fix_available = cve.get('fix_display', 'None')
+
+        rows.append(f"""
+                <tr>
+                    <td>{cve_link}</td>
+                    <td><span class="severity-badge {severity_class}">{cve.get('severity', 'UNKNOWN')}</span></td>
+                    <td style="text-align: center;"><strong style="color: #d73a49;">{cve.get('component_count', 0)}</strong></td>
+                    <td style="font-size: 0.9em; color: #666;">{component_preview}</td>
+                    <td style="text-align: center; color: {fixable_color}; font-size: 0.9em;">{fix_available}</td>
+                    <td style="text-align: center; color: {fixable_color}; font-weight: bold;">{fixable}</td>
+                </tr>""")
+
+    return f"""
+        <h2 style="margin: 40px 0 15px 0;">💥 Highest Blast Radius (CVEs affecting most components)</h2>
+        <table class="component-table">
+            <thead>
+                <tr>
+                    <th>CVE ID</th>
+                    <th>Severity</th>
+                    <th style="text-align: center;">Components</th>
+                    <th>Affected Components (preview)</th>
+                    <th style="text-align: center;">Fix Available</th>
+                    <th style="text-align: center;">Fixable</th>
+                </tr>
+            </thead>
+            <tbody>
+                {''.join(rows)}
+            </tbody>
+        </table>
+    """
+
+
+def generate_timeline(history):
+    """Generate timeline items"""
+    scans = history.get('scans', [])[-5:]  # Last 5 scans
+
+    items = []
+    for scan in reversed(scans):
+        date = format_date_short(scan['timestamp'])
+        new_count = len(scan.get('new_cves', []))
+        fixed_count = len(scan.get('fixed_cves', []))
+
+        if new_count > 0:
+            items.append(f'<li><span class="date">{date}</span> - {new_count} new CVEs detected</li>')
+        if fixed_count > 0:
+            items.append(f'<li><span class="date">{date}</span> - {fixed_count} CVEs resolved</li>')
+
+    return '\n'.join(items) if items else '<li>No recent activity</li>'
+
+
+def calculate_trend_indicator(scans):
+    """Calculate week-over-week trend indicator"""
+    if len(scans) < 2:
+        return "—"
+
+    latest = scans[-1].get('summary', {}).get('by_severity', {})
+    previous = scans[-2].get('summary', {}).get('by_severity', {})
+
+    latest_total = latest.get('CRITICAL', 0) + latest.get('HIGH', 0)
+    previous_total = previous.get('CRITICAL', 0) + previous.get('HIGH', 0)
+
+    delta = latest_total - previous_total
+
+    if delta > 0:
+        return f"+{delta}"
+    elif delta < 0:
+        return str(delta)
+    else:
+        return "0"
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate HTML CVE trend dashboard')
+    parser.add_argument('--reports-dir', default='reports',
+                       help='Reports directory (default: reports)')
+    parser.add_argument('--release', required=True,
+                       help='Release name (e.g., release-2.17)')
+    parser.add_argument('--output',
+                       help='Output HTML file path (default: reports/trends/{release}-dashboard.html)')
+
+    args = parser.parse_args()
+
+    # Load history
+    history_file = Path(args.reports_dir) / 'trends' / f"{args.release}-history.json"
+
+    if not history_file.exists():
+        console.print(f"[red]History file not found: {history_file}[/red]")
+        console.print("[yellow]Run a scan first to generate history data[/yellow]")
+        sys.exit(1)
+
+    try:
+        with open(history_file, 'r') as f:
+            history = json.load(f)
+    except Exception as e:
+        console.print(f"[red]Error loading history: {e}[/red]")
+        sys.exit(1)
+
+    scans = history.get('scans', [])
+
+    if not scans:
+        console.print("[yellow]No scan data available[/yellow]")
+        sys.exit(0)
+
+    console.print(f"[cyan]Generating HTML dashboard for {args.release}...[/cyan]")
+
+    # Load git metadata from extras
+    extras_metadata = load_extras_metadata()
+
+    # Get latest scan
+    latest_scan = scans[-1]
+    latest_severity = latest_scan.get('summary', {}).get('by_severity', {})
+
+    # Generate HTML components
+    html = HTML_TEMPLATE.format(
+        release=args.release,
+        last_updated=format_timestamp(latest_scan['timestamp']),
+        scan_count=len(scans),
+        latest_critical=latest_severity.get('CRITICAL', 0),
+        latest_high=latest_severity.get('HIGH', 0),
+        total_cves=latest_scan.get('summary', {}).get('total_cves', 0),
+        total_instances=latest_scan.get('summary', {}).get('total_matches', 0),
+        trend_indicator=calculate_trend_indicator(scans),
+        chart_data_js=generate_chart_data(history),
+        component_rows=generate_component_rows(latest_scan, extras_metadata),
+        blast_radius_section=generate_blast_radius_section(latest_scan),
+        new_cves_section=generate_new_cves_section(latest_scan),
+        fixed_cves_section=generate_fixed_cves_section(latest_scan),
+        timeline_items=generate_timeline(history)
+    )
+
+    # Determine output path
+    output_path = args.output
+    if not output_path:
+        output_path = Path(args.reports_dir) / 'trends' / f"{args.release}-dashboard.html"
+    else:
+        output_path = Path(output_path)
+
+    # Ensure directory exists
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write HTML
+    try:
+        with open(output_path, 'w') as f:
+            f.write(html)
+        console.print(f"[green]✓ Dashboard generated: {output_path}[/green]")
+    except Exception as e:
+        console.print(f"[red]Error writing HTML: {e}[/red]")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/import_scan_batch.py
+++ b/scripts/import_scan_batch.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Import batch of Grype JSON scans into trend history"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from rich.console import Console
+
+console = Console()
+
+
+def aggregate_scan_results(json_dir):
+    """Aggregate all component scans from a directory into single summary"""
+    json_path = Path(json_dir)
+
+    if not json_path.exists():
+        console.print(f"[red]Directory not found: {json_dir}[/red]")
+        return None
+
+    # Find all Grype JSON files
+    grype_files = list(json_path.glob('*_grype.json'))
+
+    if not grype_files:
+        console.print(f"[yellow]No Grype JSON files found in {json_dir}[/yellow]")
+        return None
+
+    console.print(f"[cyan]Found {len(grype_files)} component scans[/cyan]")
+
+    # Aggregate CVEs across all components
+    all_cves = set()
+    severity_counts = {'CRITICAL': 0, 'HIGH': 0, 'MEDIUM': 0, 'LOW': 0, 'NEGLIGIBLE': 0, 'UNKNOWN': 0}
+    component_breakdown = {}
+    all_cve_details = []
+
+    for grype_file in grype_files:
+        # Extract component name from filename
+        component_name = grype_file.stem.replace('_grype', '').split('_', 1)[1] if '_' in grype_file.stem else grype_file.stem
+
+        try:
+            with open(grype_file, 'r') as f:
+                scan_data = json.load(f)
+        except Exception as e:
+            console.print(f"[yellow]Warning: Failed to load {grype_file.name}: {e}[/yellow]")
+            continue
+
+        matches = scan_data.get('matches', [])
+
+        # Track per-component CVEs
+        if component_name not in component_breakdown:
+            component_breakdown[component_name] = {
+                'CRITICAL': 0, 'HIGH': 0, 'MEDIUM': 0, 'LOW': 0, 'total': 0
+            }
+
+        for match in matches:
+            vuln = match.get('vulnerability', {})
+            artifact = match.get('artifact', {})
+
+            cve_id = vuln.get('id', 'UNKNOWN')
+            severity = vuln.get('severity', 'UNKNOWN').upper()
+
+            # Add to global CVE set
+            all_cves.add(cve_id)
+
+            # Count by severity
+            if severity in severity_counts:
+                severity_counts[severity] += 1
+
+            # Count per-component
+            if severity in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
+                component_breakdown[component_name][severity] += 1
+            component_breakdown[component_name]['total'] += 1
+
+            # Store CVE details
+            all_cve_details.append({
+                'cve_id': cve_id,
+                'severity': severity,
+                'component': component_name,
+                'fixed_versions': vuln.get('fix', {}).get('versions', []),
+                'fixable': len(vuln.get('fix', {}).get('versions', [])) > 0
+            })
+
+    return {
+        'total_cves': len(all_cves),
+        'total_matches': sum(severity_counts.values()),
+        'by_severity': severity_counts,
+        'component_breakdown': component_breakdown,
+        'cve_details': all_cve_details
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Import batch scan results into trend history')
+    parser.add_argument('--json-dir', required=True,
+                       help='Directory containing Grype JSON files (e.g., reports/2.17.0/json/)')
+    parser.add_argument('--release', required=True,
+                       help='Release name (e.g., release-2.17)')
+    parser.add_argument('--reports-dir', default='reports',
+                       help='Reports directory (default: reports)')
+    parser.add_argument('--timestamp',
+                       help='ISO timestamp for this scan (default: now)')
+    parser.add_argument('--github-run-id',
+                       help='GitHub Actions run ID')
+
+    args = parser.parse_args()
+
+    console.print(f"[cyan]Aggregating scans from {args.json_dir}...[/cyan]")
+
+    # Aggregate all component scans
+    summary = aggregate_scan_results(args.json_dir)
+
+    if not summary:
+        console.print("[red]Failed to aggregate scan results[/red]")
+        sys.exit(1)
+
+    console.print(f"[green]✓ Aggregated {summary['total_cves']} unique CVEs across {len(summary['component_breakdown'])} components[/green]")
+
+    # Load or create history
+    trends_dir = Path(args.reports_dir) / 'trends'
+    trends_dir.mkdir(parents=True, exist_ok=True)
+
+    history_file = trends_dir / f"{args.release}-history.json"
+
+    if history_file.exists():
+        with open(history_file, 'r') as f:
+            history = json.load(f)
+    else:
+        history = {
+            "release": args.release,
+            "scans": [],
+            "metadata": {
+                "created": datetime.utcnow().isoformat() + "Z",
+                "last_updated": None,
+                "scan_frequency": "weekly",
+                "retention_weeks": 26
+            }
+        }
+
+    # Get previous scan for comparison
+    previous_scan = history['scans'][-1]['summary'] if history.get('scans') else None
+
+    # Detect new and fixed CVEs
+    new_cves = []
+    fixed_cves = []
+
+    if previous_scan:
+        current_cve_set = {
+            (cve['cve_id'], cve['component'])
+            for cve in summary['cve_details']
+        }
+
+        previous_cve_set = {
+            (cve['cve_id'], cve['component'])
+            for cve in previous_scan.get('cve_details', [])
+        }
+
+        # New CVEs
+        new_cve_keys = current_cve_set - previous_cve_set
+        new_cves = [
+            cve for cve in summary['cve_details']
+            if (cve['cve_id'], cve['component']) in new_cve_keys
+        ]
+
+        # Fixed CVEs
+        fixed_cve_keys = previous_cve_set - current_cve_set
+        fixed_cves = [
+            {'cve_id': cve_id, 'component': component}
+            for cve_id, component in fixed_cve_keys
+        ]
+
+    # Create scan record
+    scan_record = {
+        'timestamp': args.timestamp or (datetime.utcnow().isoformat() + 'Z'),
+        'json_dir': args.json_dir,
+        'github_run_id': args.github_run_id,
+        'summary': {
+            'total_cves': summary['total_cves'],
+            'total_matches': summary['total_matches'],
+            'by_severity': summary['by_severity'],
+            'component_breakdown': summary['component_breakdown'],
+            'cve_details': summary['cve_details']  # Keep for next scan comparison
+        },
+        'new_cves': new_cves,
+        'fixed_cves': fixed_cves
+    }
+
+    # Append to history
+    history['scans'].append(scan_record)
+    history['metadata']['last_updated'] = datetime.utcnow().isoformat() + 'Z'
+
+    # Save history
+    with open(history_file, 'w') as f:
+        json.dump(history, f, indent=2)
+
+    console.print(f"[green]✓ Scan added to history: {history_file}[/green]")
+    console.print(f"\n[bold]Summary[/bold]")
+    console.print(f"  Total CVEs: {summary['total_cves']}")
+    console.print(f"  CRITICAL: {summary['by_severity']['CRITICAL']}")
+    console.print(f"  HIGH: {summary['by_severity']['HIGH']}")
+
+    if new_cves:
+        console.print(f"\n[yellow]  New CVEs: {len(new_cves)}[/yellow]")
+    if fixed_cves:
+        console.print(f"[green]  Fixed CVEs: {len(fixed_cves)}[/green]")
+
+    console.print(f"\n[cyan]Total scans in history: {len(history['scans'])}[/cyan]")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/import_scan_batch.py
+++ b/scripts/import_scan_batch.py
@@ -4,7 +4,7 @@
 import argparse
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from rich.console import Console
@@ -136,7 +136,7 @@ def main():
             "release": args.release,
             "scans": [],
             "metadata": {
-                "created": datetime.utcnow().isoformat() + "Z",
+                "created": datetime.now(timezone.utc).isoformat() + "Z",
                 "last_updated": None,
                 "scan_frequency": "weekly",
                 "retention_weeks": 26
@@ -177,7 +177,7 @@ def main():
 
     # Create scan record
     scan_record = {
-        'timestamp': args.timestamp or (datetime.utcnow().isoformat() + 'Z'),
+        'timestamp': args.timestamp or (datetime.now(timezone.utc).isoformat() + 'Z'),
         'json_dir': args.json_dir,
         'github_run_id': args.github_run_id,
         'summary': {
@@ -193,7 +193,7 @@ def main():
 
     # Append to history
     history['scans'].append(scan_record)
-    history['metadata']['last_updated'] = datetime.utcnow().isoformat() + 'Z'
+    history['metadata']['last_updated'] = datetime.now(timezone.utc).isoformat() + 'Z'
 
     # Save history
     with open(history_file, 'w') as f:

--- a/scripts/import_scan_batch.py
+++ b/scripts/import_scan_batch.py
@@ -36,8 +36,13 @@ def aggregate_scan_results(json_dir):
     all_cve_details = []
 
     for grype_file in grype_files:
-        # Extract component name from filename
-        component_name = grype_file.stem.replace('_grype', '').split('_', 1)[1] if '_' in grype_file.stem else grype_file.stem
+        # Extract component name from filename (safe split)
+        stem = grype_file.stem.replace('_grype', '')
+        if '_' in stem:
+            parts = stem.split('_', 1)
+            component_name = parts[1] if len(parts) > 1 else stem
+        else:
+            component_name = stem
 
         try:
             with open(grype_file, 'r') as f:

--- a/scripts/load_cve_descriptions.py
+++ b/scripts/load_cve_descriptions.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Load CVE descriptions from Grype scan results"""
+
+import json
+from pathlib import Path
+
+
+def load_cve_descriptions(json_dir='reports'):
+    """Load CVE descriptions from Grype JSON files
+
+    Returns:
+        dict: {cve_id: {description, cvss_score}}
+    """
+    # Try to find most recent scan JSONs
+    reports_path = Path(json_dir)
+
+    # Look for version directories (e.g., 2.17.0)
+    version_dirs = list(reports_path.glob('*/json'))
+    if not version_dirs:
+        return {}
+
+    # Use most recent (assume highest version number or latest mtime)
+    latest_dir = max(version_dirs, key=lambda p: p.stat().st_mtime)
+
+    cve_desc_map = {}
+
+    for json_file in latest_dir.glob('*_grype.json'):
+        try:
+            with open(json_file, 'r') as f:
+                data = json.load(f)
+
+            for match in data.get('matches', []):
+                vuln = match.get('vulnerability', {})
+                cve_id = vuln.get('id')
+                description = vuln.get('description', '')
+
+                # Extract CVSS score if available
+                cvss_score = None
+                cvss_list = vuln.get('cvss', [])
+                if cvss_list and isinstance(cvss_list, list) and len(cvss_list) > 0:
+                    # Get first CVSS entry
+                    cvss_entry = cvss_list[0]
+                    if isinstance(cvss_entry, dict):
+                        metrics = cvss_entry.get('metrics', {})
+                        cvss_score = metrics.get('baseScore')
+
+                if cve_id and cve_id not in cve_desc_map:
+                    cve_desc_map[cve_id] = {
+                        'description': description,
+                        'cvss_score': cvss_score
+                    }
+        except Exception:
+            continue
+
+    return cve_desc_map

--- a/scripts/load_extras_metadata.py
+++ b/scripts/load_extras_metadata.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Load git metadata from extras/*.json files"""
+
+import json
+from pathlib import Path
+
+
+def load_extras_metadata(extras_dir='extras'):
+    """Load git metadata from extras JSON files
+
+    Returns:
+        dict: {image_key: {git_url, git_revision}}
+    """
+    extras_path = Path(extras_dir)
+
+    if not extras_path.exists():
+        return {}
+
+    metadata = {}
+
+    # Find all JSON files in extras directory
+    json_files = list(extras_path.glob('*.json'))
+
+    for json_file in json_files:
+        try:
+            with open(json_file, 'r') as f:
+                data = json.load(f)
+
+            # extras/*.json is an array of component objects
+            for component in data:
+                image_key = component.get('image-key')
+                git_url = component.get('git-url')
+                git_revision = component.get('git-revision')
+
+                if image_key:
+                    metadata[image_key] = {
+                        'git_url': git_url,
+                        'git_revision': git_revision,
+                        'commit_url': f"{git_url}/commit/{git_revision}" if git_url and git_revision else None
+                    }
+        except Exception:
+            continue
+
+    return metadata

--- a/scripts/slack_cve_report.py
+++ b/scripts/slack_cve_report.py
@@ -356,12 +356,23 @@ def create_slack_message(version, results, format_type='summary', image_details=
         github_repository = os.getenv('GITHUB_REPOSITORY')
         if github_run_id and github_repository:
             artifacts_url = f"https://github.com/{github_repository}/actions/runs/{github_run_id}"
+
+            # Check if trend dashboard exists
+            reports_dir = os.getenv('REPORTS_DIR', 'reports')
+            trends_dir = Path(reports_dir) / 'trends'
+            version_slug = version.replace('.', '')
+            trend_dashboard = trends_dir / f"release-{version_slug}-dashboard.html"
+
+            link_text = f"📊 <{artifacts_url}|View detailed reports in workflow artifacts>"
+            if trend_dashboard.exists():
+                link_text += " | 📈 Trend dashboard included"
+
             blocks.append({"type": "divider"})
             blocks.append({
                 "type": "context",
                 "elements": [{
                     "type": "mrkdwn",
-                    "text": f"📊 <{artifacts_url}|View detailed reports in workflow artifacts>"
+                    "text": link_text
                 }]
             })
 

--- a/scripts/slack_cve_report.py
+++ b/scripts/slack_cve_report.py
@@ -357,11 +357,12 @@ def create_slack_message(version, results, format_type='summary', image_details=
         if github_run_id and github_repository:
             artifacts_url = f"https://github.com/{github_repository}/actions/runs/{github_run_id}"
 
-            # Check if trend dashboard exists
+            # Check if trend dashboard exists (filename is {release}-dashboard.html)
             reports_dir = os.getenv('REPORTS_DIR', 'reports')
             trends_dir = Path(reports_dir) / 'trends'
-            version_slug = version.replace('.', '')
-            trend_dashboard = trends_dir / f"release-{version_slug}-dashboard.html"
+            # Extract release from version (e.g., "2.17.0" -> "release-2.17")
+            release = f"release-{'.'.join(version.split('.')[:2])}"
+            trend_dashboard = trends_dir / f"{release}-dashboard.html"
 
             link_text = f"📊 <{artifacts_url}|View detailed reports in workflow artifacts>"
             if trend_dashboard.exists():

--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -5,7 +5,7 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from rich.console import Console
@@ -20,7 +20,7 @@ def load_history(history_file):
             "release": None,
             "scans": [],
             "metadata": {
-                "created": datetime.utcnow().isoformat() + "Z",
+                "created": datetime.now(timezone.utc).isoformat() + "Z",
                 "last_updated": None,
                 "scan_frequency": "weekly",
                 "retention_weeks": 26,
@@ -31,7 +31,7 @@ def load_history(history_file):
     try:
         with open(history_file, 'r') as f:
             return json.load(f)
-    except Exception as e:
+    except (OSError, json.JSONDecodeError) as e:
         console.print(f"[red]Error loading history file: {e}[/red]")
         sys.exit(1)
 
@@ -164,7 +164,7 @@ def prune_old_scans(history, retention_weeks=None, max_scans=None):
 
     # Then apply time-based retention (if specified)
     if retention_weeks:
-        cutoff = datetime.utcnow().timestamp() - (retention_weeks * 7 * 24 * 60 * 60)
+        cutoff = datetime.now(timezone.utc).timestamp() - (retention_weeks * 7 * 24 * 60 * 60)
         history['scans'] = [
             scan for scan in history['scans']
             if datetime.fromisoformat(scan['timestamp'].replace('Z', '')).timestamp() > cutoff
@@ -218,7 +218,7 @@ def main():
     try:
         with open(scan_report_path, 'r') as f:
             scan_report = json.load(f)
-    except Exception as e:
+    except (OSError, json.JSONDecodeError) as e:
         console.print(f"[red]Error loading scan report: {e}[/red]")
         sys.exit(1)
 
@@ -244,7 +244,7 @@ def main():
 
     # Create scan record
     scan_record = {
-        'timestamp': datetime.utcnow().isoformat() + 'Z',
+        'timestamp': datetime.now(timezone.utc).isoformat() + 'Z',
         'scan_report_path': str(scan_report_path),
         'github_run_id': args.github_run_id or os.environ.get('GITHUB_RUN_ID'),
         'summary': {
@@ -259,7 +259,7 @@ def main():
 
     # Append to history
     history['scans'].append(scan_record)
-    history['metadata']['last_updated'] = datetime.utcnow().isoformat() + 'Z'
+    history['metadata']['last_updated'] = datetime.now(timezone.utc).isoformat() + 'Z'
 
     # Prune old scans
     retention_weeks = history['metadata'].get('retention_weeks', 26)
@@ -271,7 +271,7 @@ def main():
         with open(history_file, 'w') as f:
             json.dump(history, f, indent=2)
         console.print(f"[green]✓ Scan results stored: {history_file}[/green]")
-    except Exception as e:
+    except (OSError, json.JSONDecodeError) as e:
         console.print(f"[red]Error saving history: {e}[/red]")
         sys.exit(1)
 

--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Store CVE scan results for historical trend tracking"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+from rich.console import Console
+
+console = Console()
+
+
+def load_history(history_file):
+    """Load existing scan history or create new structure"""
+    if not history_file.exists():
+        return {
+            "release": None,
+            "scans": [],
+            "metadata": {
+                "created": datetime.utcnow().isoformat() + "Z",
+                "last_updated": None,
+                "scan_frequency": "weekly",
+                "retention_weeks": 26,
+                "max_scans": 4
+            }
+        }
+
+    try:
+        with open(history_file, 'r') as f:
+            return json.load(f)
+    except Exception as e:
+        console.print(f"[red]Error loading history file: {e}[/red]")
+        sys.exit(1)
+
+
+def extract_scan_summary(scan_report):
+    """Extract summary statistics from Grype JSON report"""
+    matches = scan_report.get('matches', [])
+
+    # Count by severity
+    severity_counts = {
+        'CRITICAL': 0,
+        'HIGH': 0,
+        'MEDIUM': 0,
+        'LOW': 0,
+        'NEGLIGIBLE': 0,
+        'UNKNOWN': 0
+    }
+
+    # Track unique CVEs and components
+    cve_set = set()
+    component_breakdown = {}
+    cve_details = []
+
+    for match in matches:
+        vuln = match.get('vulnerability', {})
+        artifact = match.get('artifact', {})
+
+        cve_id = vuln.get('id', 'UNKNOWN')
+        severity = vuln.get('severity', 'UNKNOWN').upper()
+        component = artifact.get('name', 'unknown')
+
+        # Count by severity
+        if severity in severity_counts:
+            severity_counts[severity] += 1
+
+        # Track unique CVEs
+        cve_set.add(cve_id)
+
+        # Track per-component breakdown
+        if component not in component_breakdown:
+            component_breakdown[component] = {
+                'CRITICAL': 0,
+                'HIGH': 0,
+                'MEDIUM': 0,
+                'LOW': 0,
+                'total': 0
+            }
+
+        if severity in ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']:
+            component_breakdown[component][severity] += 1
+        component_breakdown[component]['total'] += 1
+
+        # Store CVE details for new/fixed detection
+        cve_details.append({
+            'cve_id': cve_id,
+            'severity': severity,
+            'component': component,
+            'fixed_versions': vuln.get('fix', {}).get('versions', []),
+            'fixable': len(vuln.get('fix', {}).get('versions', [])) > 0
+        })
+
+    return {
+        'total_cves': len(cve_set),
+        'total_matches': len(matches),
+        'by_severity': severity_counts,
+        'component_breakdown': component_breakdown,
+        'cve_details': cve_details
+    }
+
+
+def detect_changes(current_scan, previous_scan):
+    """Detect new and fixed CVEs compared to previous scan"""
+    if not previous_scan:
+        return [], []
+
+    current_cves = {
+        (cve['cve_id'], cve['component'])
+        for cve in current_scan.get('cve_details', [])
+    }
+
+    previous_cves = {
+        (cve['cve_id'], cve['component'])
+        for cve in previous_scan.get('cve_details', [])
+    }
+
+    new_cves = current_cves - previous_cves
+    fixed_cves = previous_cves - current_cves
+
+    # Get full details for new CVEs
+    new_cve_details = [
+        cve for cve in current_scan.get('cve_details', [])
+        if (cve['cve_id'], cve['component']) in new_cves
+    ]
+
+    # Get CVE IDs for fixed CVEs
+    fixed_cve_ids = [
+        {'cve_id': cve_id, 'component': component}
+        for cve_id, component in fixed_cves
+    ]
+
+    return new_cve_details, fixed_cve_ids
+
+
+def detect_release_from_extras(extras_dir):
+    """Auto-detect release version from extras directory"""
+    extras_path = Path(extras_dir)
+    if not extras_path.exists():
+        return None
+
+    # Look for version pattern in JSON filenames (e.g., 2.17.0.json)
+    for json_file in extras_path.glob('*.json'):
+        name = json_file.stem
+        parts = name.split('.')
+        if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+            return f"release-{parts[0]}.{parts[1]}"
+
+    return None
+
+
+def prune_old_scans(history, retention_weeks=None, max_scans=None):
+    """Remove scans older than retention period or beyond max count"""
+    if not history.get('scans'):
+        return
+
+    # Apply max_scans limit first (keep most recent N scans)
+    if max_scans and len(history['scans']) > max_scans:
+        # Sort by timestamp descending, keep newest max_scans
+        history['scans'].sort(key=lambda s: s['timestamp'], reverse=True)
+        history['scans'] = history['scans'][:max_scans]
+
+    # Then apply time-based retention (if specified)
+    if retention_weeks:
+        cutoff = datetime.utcnow().timestamp() - (retention_weeks * 7 * 24 * 60 * 60)
+        history['scans'] = [
+            scan for scan in history['scans']
+            if datetime.fromisoformat(scan['timestamp'].replace('Z', '')).timestamp() > cutoff
+        ]
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Store CVE scan results for trend tracking')
+    parser.add_argument('--reports-dir', default='reports',
+                       help='Reports directory (default: reports)')
+    parser.add_argument('--extras-dir', default='extras',
+                       help='Extras directory for release detection (default: extras)')
+    parser.add_argument('--release',
+                       help='Release name (e.g., release-2.17). Auto-detected if not provided')
+    parser.add_argument('--scan-report',
+                       help='Path to Grype JSON scan report. Defaults to latest in reports dir')
+    parser.add_argument('--github-run-id',
+                       help='GitHub Actions run ID for reference')
+
+    args = parser.parse_args()
+
+    # Detect release if not provided
+    release = args.release
+    if not release:
+        release = detect_release_from_extras(args.extras_dir)
+        if not release:
+            console.print("[red]Could not auto-detect release. Use --release flag[/red]")
+            sys.exit(1)
+
+    console.print(f"[cyan]Storing scan results for {release}[/cyan]")
+
+    # Find scan report
+    scan_report_path = args.scan_report
+    if not scan_report_path:
+        # Look for latest Grype JSON in reports dir
+        reports_path = Path(args.reports_dir)
+        json_files = list(reports_path.glob('*-grype.json'))
+        if not json_files:
+            console.print(f"[red]No Grype JSON reports found in {args.reports_dir}[/red]")
+            sys.exit(1)
+        scan_report_path = max(json_files, key=lambda p: p.stat().st_mtime)
+
+    scan_report_path = Path(scan_report_path)
+    if not scan_report_path.exists():
+        console.print(f"[red]Scan report not found: {scan_report_path}[/red]")
+        sys.exit(1)
+
+    console.print(f"[cyan]Loading scan report: {scan_report_path}[/cyan]")
+
+    # Load scan report
+    try:
+        with open(scan_report_path, 'r') as f:
+            scan_report = json.load(f)
+    except Exception as e:
+        console.print(f"[red]Error loading scan report: {e}[/red]")
+        sys.exit(1)
+
+    # Extract summary
+    summary = extract_scan_summary(scan_report)
+
+    # Load or create history
+    trends_dir = Path(args.reports_dir) / 'trends'
+    trends_dir.mkdir(parents=True, exist_ok=True)
+
+    history_file = trends_dir / f"{release}-history.json"
+    history = load_history(history_file)
+
+    # Set release name if new history
+    if not history.get('release'):
+        history['release'] = release
+
+    # Get previous scan for comparison
+    previous_scan = history['scans'][-1]['summary'] if history.get('scans') else None
+
+    # Detect new and fixed CVEs
+    new_cves, fixed_cves = detect_changes(summary, previous_scan)
+
+    # Create scan record
+    scan_record = {
+        'timestamp': datetime.utcnow().isoformat() + 'Z',
+        'scan_report_path': str(scan_report_path),
+        'github_run_id': args.github_run_id or os.environ.get('GITHUB_RUN_ID'),
+        'summary': {
+            'total_cves': summary['total_cves'],
+            'total_matches': summary['total_matches'],
+            'by_severity': summary['by_severity'],
+            'component_breakdown': summary['component_breakdown']
+        },
+        'new_cves': new_cves,
+        'fixed_cves': fixed_cves
+    }
+
+    # Append to history
+    history['scans'].append(scan_record)
+    history['metadata']['last_updated'] = datetime.utcnow().isoformat() + 'Z'
+
+    # Prune old scans
+    retention_weeks = history['metadata'].get('retention_weeks', 26)
+    max_scans = history['metadata'].get('max_scans', 4)
+    prune_old_scans(history, retention_weeks=retention_weeks, max_scans=max_scans)
+
+    # Save history
+    try:
+        with open(history_file, 'w') as f:
+            json.dump(history, f, indent=2)
+        console.print(f"[green]✓ Scan results stored: {history_file}[/green]")
+    except Exception as e:
+        console.print(f"[red]Error saving history: {e}[/red]")
+        sys.exit(1)
+
+    # Print summary
+    console.print(f"\n[bold]Scan Summary[/bold]")
+    console.print(f"  Total CVEs: {summary['total_cves']}")
+    console.print(f"  CRITICAL: {summary['by_severity']['CRITICAL']}")
+    console.print(f"  HIGH: {summary['by_severity']['HIGH']}")
+
+    if new_cves:
+        console.print(f"\n[yellow]  New CVEs: {len(new_cves)}[/yellow]")
+    if fixed_cves:
+        console.print(f"[green]  Fixed CVEs: {len(fixed_cves)}[/green]")
+
+    console.print(f"\n[cyan]Total scans in history: {len(history['scans'])}[/cyan]")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

Adds CVE trend analysis dashboard with automated weekly GitHub Actions workflow.

## Features

### 📊 CVE Trend Dashboard
- **Multi-release comparison** - Tabbed interface for 2.15, 2.16, 2.17, etc.
- **Trend tracking** - Max 4 scans per release (rolling window)
- **New/Fixed CVE detection** - Week-over-week comparison
- **Blast radius analysis** - CVEs affecting most components
- **Component drill-down** - Click component → modal shows all CVEs

### 🎨 Interactive UI
- **CVSS score column** - Color-coded by severity (Critical=red, High=orange, Medium=yellow, Low=gray)
- **Sortable tables** - Click headers to sort by CVE ID, Severity, CVSS, Component count
- **Tooltips** - Hover CVE for description + CVSS score
- **Internal vs External** - Separate stolostron components from upstream dependencies
- **Commit links** - Internal components link to GitHub commits
- **CVE database links** - CVE-* → NVD, GO-* → Go vulnerability DB

### 🤖 Automated GitHub Actions
- **Friday 9 AM UTC** - Scans all releases automatically
- **Auto-storage** - Saves to reports/trends/*-history.json
- **Auto-dashboard** - Generates multi-release-dashboard.html
- **Auto-commit** - Commits and pushes to main branch
- **Manual trigger** - Can run workflow manually for any release

### 📁 Files Added
- `scripts/store_scan_results.py` - Store scan results to history
- `scripts/generate_multi_release_dashboard.py` - Multi-release dashboard generator
- `scripts/analyze_cve_blast_radius.py` - Blast radius analysis
- `scripts/load_cve_descriptions.py` - CVE descriptions/CVSS loader
- `scripts/load_extras_metadata.py` - Git metadata for commit links
- `scripts/cve_trends.py` - CLI trend report
- `scripts/generate_trend_report.py` - Single release HTML dashboard
- `scripts/import_scan_batch.py` - Import GitHub Actions artifacts

### 🎯 Makefile Targets
```bash
make cve-trends RELEASE=release-2.17       # CLI trend analysis
make cve-trends-html RELEASE=release-2.17  # Single release dashboard
make cve-trends-multi                      # Multi-release comparison
```

## Usage

### Automated (Production)
1. Wait for Friday 9 AM UTC
2. Pull latest: `git pull origin main`
3. Open: `reports/trends/multi-release-dashboard.html`

### Manual Testing
```bash
# Scan a release
make scan-cves-json-icsp RELEASE=release-2.17

# Generate multi-release dashboard
make cve-trends-multi

# Open dashboard
open reports/trends/multi-release-dashboard.html
```

## Screenshots

Dashboard shows:
- Tab per release (version from reports/{version}/)
- Summary cards (Critical, High, Unique CVEs, Week-over-Week trend)
- Trend charts (CVE count over time, New vs Fixed)
- Blast radius table (top CVEs by component impact)
- Internal components table (stolostron with commit links)
- External components table (upstream dependencies)
- Fixed CVEs table (resolved vulnerabilities)

## Testing Checklist
- [x] Local scan generates history JSON
- [x] Multi-release dashboard renders correctly
- [x] Component drill-down modal works
- [x] CVSS scores display and sort
- [x] Tooltips show CVE descriptions
- [x] Tab switching works
- [x] Sortable tables function
- [x] Commit links navigate to GitHub
- [x] CVE links navigate to NVD/Go vuln DB
- [ ] GitHub Actions workflow runs successfully (will test on merge)
- [ ] Auto-commit pushes to main (will test Friday)

## Next Steps
1. Merge to main
2. Monitor Friday's automated run
3. Port to mce-operator-bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CVE trend tracking with historical analysis and week-over-week comparisons
  * HTML dashboards displaying CVE trends across releases with component breakdown and blast radius analysis
  * Multi-release comparison dashboard for cross-version CVE trend analysis
  * Automated trend dashboard generation and repository updates on scheduled scans
  * Enhanced notifications with trend dashboard links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->