### PR TITLE
fix: YAML syntax error in weekly-cve-scan workflow

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -373,13 +373,16 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "chore: update CVE trend dashboards (automated weekly scan)
+            git commit -m "$(cat <<'EOF'
+          chore: update CVE trend dashboards (automated weekly scan)
 
-Weekly CVE scan results for:
-$(ls reports/trends/*-history.json | xargs -n1 basename | sed 's/-history.json//' | sed 's/^/- /')
+          Weekly CVE scan results for:
+          $(ls reports/trends/*-history.json | xargs -n1 basename | sed 's/-history.json//' | sed 's/^/- /')
 
-Generated: $(date -u '+%Y-%m-%d %H:%M UTC')
-Run: ${{ github.run_id }}"
+          Generated: $(date -u '+%Y-%m-%d %H:%M UTC')
+          Run: ${{ github.run_id }}
+          EOF
+          )"
 
             git push
             echo "✓ Changes committed and pushed"


### PR DESCRIPTION
## Summary
Fixes YAML syntax error on line 379 in weekly-cve-scan.yml

## Problem
Multi-line commit message in `git commit -m` flag breaks YAML parsing when it contains `$(command substitution)` and GitHub Actions variables.

## Solution
Use heredoc with `cat <<'EOF'` to properly escape multi-line commit message.

## Testing
- [x] YAML validates
- [ ] Workflow runs successfully