### PR TITLE
feat: add release-5.0 to weekly CVE scan workflow

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -12,9 +12,10 @@ on:
       release_branch:
         description: 'Release branch to scan'
         required: false
-        default: 'release-2.17'
+        default: 'release-5.0'
         type: choice
         options:
+          - release-5.0
           - release-2.17
           - release-2.16
           - release-2.15
@@ -42,7 +43,7 @@ jobs:
     # Scan multiple releases on scheduled runs or when "all" is selected
     strategy:
       matrix:
-        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["release-2.17", "release-2.16", "release-2.15", "release-2.14", "release-2.13"]') || inputs.release_branch == 'all' && fromJSON('["release-2.17", "release-2.16", "release-2.15", "release-2.14", "release-2.13", "release-2.12", "release-2.11"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
+        release_branch: ${{ github.event_name == 'schedule' && fromJSON('["release-5.0", "release-2.17", "release-2.16", "release-2.15", "release-2.14", "release-2.13"]') || inputs.release_branch == 'all' && fromJSON('["release-5.0", "release-2.17", "release-2.16", "release-2.15", "release-2.14", "release-2.13", "release-2.12", "release-2.11"]') || fromJSON(format('["{0}"]', inputs.release_branch)) }}
       fail-fast: false
 
     env:


### PR DESCRIPTION
## Summary
Add release-5.0 branch to CVE scan workflow

## Changes
- Add release-5.0 to workflow_dispatch dropdown (new default)
- Add to scheduled scan matrix (top 6 releases)
- Add to 'all' option (2.11+)