### PR TITLE
fix: f-string syntax and grype filename pattern

### DIFF
--- a/scripts/generate_multi_release_dashboard.py
+++ b/scripts/generate_multi_release_dashboard.py
@@ -1090,7 +1090,7 @@ def generate_release_tab_content(release, history, extras_metadata=None):
                 {''.join(external_rows)}
             </tbody>
         </table>
-        {'<button class="show-all-btn" onclick="toggleShowAll(\'' + tab_id + '\', \'external\')">Show All External (' + str(len(external_components)) + ' total)</button>' if len(external_components) > 15 else ''}
+        {f'<button class="show-all-btn" onclick="toggleShowAll({chr(39)}{tab_id}{chr(39)}, {chr(39)}external{chr(39)})">Show All External ({len(external_components)} total)</button>' if len(external_components) > 15 else ''}
 
         {generate_fixed_cves_section(latest_scan, tab_id)}
     </div>"""

--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -201,7 +201,7 @@ def main():
     if not scan_report_path:
         # Look for latest Grype JSON in reports dir (search recursively)
         reports_path = Path(args.reports_dir)
-        json_files = list(reports_path.rglob('*-grype.json'))
+        json_files = list(reports_path.rglob('*_grype.json'))
         if not json_files:
             console.print(f"[red]No Grype JSON reports found in {args.reports_dir}[/red]")
             sys.exit(1)


### PR DESCRIPTION
## Summary
Fix Python 3.12+ syntax error and grype file pattern mismatch

## Problems
1. SyntaxError at generate_multi_release_dashboard.py:1096 - backslash in f-string expression
2. store_scan_results.py searches for `*-grype.json` but scan creates `*_grype.json`

## Solutions
1. Replace escaped quotes with chr(39)
2. Fix pattern from dash to underscore

## Testing
Fixes aggregate-and-commit job syntax error and file not found error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scan report file discovery to recognize alternate naming patterns.
  * Refined internal processes for dashboard generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->