### PR TITLE
fix: remove backslash from internal button f-string

### DIFF
--- a/scripts/generate_multi_release_dashboard.py
+++ b/scripts/generate_multi_release_dashboard.py
@@ -1074,7 +1074,7 @@ def generate_release_tab_content(release, history, extras_metadata=None):
                 {''.join(internal_rows)}
             </tbody>
         </table>
-        {'<button class="show-all-btn" onclick="toggleShowAll(\'' + tab_id + '\', \'internal\')">Show All Internal (' + str(len(internal_components)) + ' total)</button>' if len(internal_components) > 15 else ''}
+        {f'<button class="show-all-btn" onclick="toggleShowAll({chr(39)}{tab_id}{chr(39)}, {chr(39)}internal{chr(39)})">Show All Internal ({len(internal_components)} total)</button>' if len(internal_components) > 15 else ''}
 
         <h2 style="margin: 40px 0 15px 0;">🌐 External/Upstream Components</h2>
         <table class="component-table" id="externalTable-{tab_id}">


### PR DESCRIPTION
## Summary
Fix remaining Python 3.12+ syntax error

## Problem
Line 1077 still had backslash escape `\'` for internal button  
Previous PR #3522 only fixed external button

## Solution
Replace escaped quotes with chr(39) for internal button too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this update. Internal code improvements were made to enhance code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->