### PR TITLE
Track exact version and extras metadata for CVE trends

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -302,6 +302,15 @@ jobs:
           retention-days: 90
         continue-on-error: true
 
+      - name: Upload extras metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: extras-${{ env.RELEASE_BRANCH }}
+          path: extras/
+          retention-days: 90
+        continue-on-error: true
+
       - name: Check for critical CVEs
         run: |
           # Count critical CVEs and fail if threshold exceeded
@@ -344,7 +353,15 @@ jobs:
           path: downloaded-history/
           merge-multiple: false
 
-      - name: Merge history files
+      - name: Download all extras artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: extras-*
+          path: downloaded-extras/
+          merge-multiple: false
+        continue-on-error: true
+
+      - name: Merge history and extras files
         run: |
           echo "Merging history files from artifacts..."
           mkdir -p reports/trends
@@ -358,6 +375,23 @@ jobs:
 
           ls -la reports/trends/
           echo "✓ History files merged"
+
+          # Merge extras from all releases (later releases overwrite earlier)
+          echo "Merging extras metadata from artifacts..."
+          mkdir -p extras
+
+          for extras_dir in downloaded-extras/extras-*/; do
+            if [ -d "$extras_dir" ]; then
+              cp "$extras_dir"*.json extras/ || true
+            fi
+          done
+
+          if [ -d "extras" ] && [ "$(ls -A extras)" ]; then
+            echo "✓ Extras metadata merged"
+            ls -la extras/
+          else
+            echo "⚠️  No extras metadata found (internal/external categorization unavailable)"
+          fi
 
       - name: Generate multi-release dashboard
         run: |

--- a/scripts/generate_multi_release_dashboard.py
+++ b/scripts/generate_multi_release_dashboard.py
@@ -871,10 +871,16 @@ def get_version_from_reports(release):
     return matching[-1]
 
 
-def generate_tab_button(release, is_active=False):
+def generate_tab_button(release, history=None, is_active=False):
     """Generate tab button HTML"""
     tab_id = release.replace('.', '').replace('-', '')  # release-2.17 -> release217
-    display_name = get_version_from_reports(release)
+
+    # Try to get version from history first, fallback to reports dir
+    if history and history.get('version'):
+        display_name = history['version']
+    else:
+        display_name = get_version_from_reports(release)
+
     active_class = ' active' if is_active else ''
     return f'<button class="tab{active_class}" onclick="openTab(event, \'{tab_id}\')">{display_name}</button>'
 
@@ -1414,7 +1420,7 @@ def main():
         sys.exit(0)
 
     # Generate HTML components
-    tab_buttons = '\n'.join([generate_tab_button(rel) for rel in sorted(releases.keys())])
+    tab_buttons = '\n'.join([generate_tab_button(rel, hist) for rel, hist in sorted(releases.items())])
     tab_contents = '\n'.join([generate_release_tab_content(rel, hist, extras_metadata) for rel, hist in sorted(releases.items())])
     comparison_cards = '\n'.join([generate_comparison_card(rel, hist) for rel, hist in sorted(releases.items())])
 

--- a/scripts/store_scan_results.py
+++ b/scripts/store_scan_results.py
@@ -18,6 +18,7 @@ def load_history(history_file):
     if not history_file.exists():
         return {
             "release": None,
+            "version": None,
             "scans": [],
             "metadata": {
                 "created": datetime.now(timezone.utc).isoformat() + "Z",
@@ -136,19 +137,26 @@ def detect_changes(current_scan, previous_scan):
 
 
 def detect_release_from_extras(extras_dir):
-    """Auto-detect release version from extras directory"""
+    """Auto-detect release version from extras directory
+
+    Returns:
+        tuple: (release_name, full_version) e.g., ('release-2.17', '2.17.0')
+    """
     extras_path = Path(extras_dir)
     if not extras_path.exists():
-        return None
+        return None, None
 
     # Look for version pattern in JSON filenames (e.g., 2.17.0.json)
     for json_file in extras_path.glob('*.json'):
         name = json_file.stem
         parts = name.split('.')
-        if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
-            return f"release-{parts[0]}.{parts[1]}"
+        if len(parts) >= 3 and parts[0].isdigit() and parts[1].isdigit():
+            # Return both release-X.Y and full X.Y.Z
+            release_name = f"release-{parts[0]}.{parts[1]}"
+            full_version = name  # e.g., "2.17.0"
+            return release_name, full_version
 
-    return None
+    return None, None
 
 
 def prune_old_scans(history, retention_weeks=None, max_scans=None):
@@ -188,13 +196,19 @@ def main():
 
     # Detect release if not provided
     release = args.release
+    full_version = None
     if not release:
-        release = detect_release_from_extras(args.extras_dir)
+        release, full_version = detect_release_from_extras(args.extras_dir)
         if not release:
             console.print("[red]Could not auto-detect release. Use --release flag[/red]")
             sys.exit(1)
+    else:
+        # Manual release specified, try to get version from extras
+        _, full_version = detect_release_from_extras(args.extras_dir)
 
     console.print(f"[cyan]Storing scan results for {release}[/cyan]")
+    if full_version:
+        console.print(f"[cyan]Version: {full_version}[/cyan]")
 
     # Find scan report
     scan_report_path = args.scan_report
@@ -232,9 +246,11 @@ def main():
     history_file = trends_dir / f"{release}-history.json"
     history = load_history(history_file)
 
-    # Set release name if new history
+    # Set release name and version if new history
     if not history.get('release'):
         history['release'] = release
+    if full_version and not history.get('version'):
+        history['version'] = full_version
 
     # Get previous scan for comparison
     previous_scan = history['scans'][-1]['summary'] if history.get('scans') else None


### PR DESCRIPTION
## Summary
- Store full version (x.y.z) in history metadata from extras filename
- Upload extras/ as artifact in scan job for git_url lookup
- Download and merge extras in aggregate job for internal/external categorization  
- Display exact version in dashboard tabs from history instead of reports dir

## Fixes
- All components showing as external in multi-release dashboard (no git_url available)
- Tab labels showing x.y instead of x.y.z

## Changes
**scripts/store_scan_results.py:**
- Modified `detect_release_from_extras()` to return both release name and full version
- Added `version` field to history metadata structure
- Store detected version from extras/x.y.z.json filename

**scripts/generate_multi_release_dashboard.py:**
- Modified `generate_tab_button()` to accept history and read version from it
- Tab labels now show exact x.y.z from history instead of falling back to x.y

**.github/workflows/weekly-cve-scan.yml:**
- Added step to upload extras/ as artifact after each scan job
- Added step in aggregate job to download all extras-* artifacts
- Merge extras/ temporarily for dashboard generation (not committed)

## Test Plan
- [x] Manual trigger workflow with auto_commit=true
- [ ] Verify tabs show x.y.z versions
- [ ] Verify internal components appear (have git_url from extras)
- [ ] Verify extras/ not committed to main (only reports/trends/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CVE scan metadata collection and artifact storage for improved historical tracking
  * Improved semantic version identification in multi-release dashboard generation
  * Extended version tracking capabilities in scan result history management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->