### PR TITLE
Add skip_slack option for testing

### DIFF
--- a/.github/workflows/weekly-cve-scan.yml
+++ b/.github/workflows/weekly-cve-scan.yml
@@ -34,6 +34,11 @@ on:
         required: false
         default: false
         type: boolean
+      skip_slack:
+        description: 'Skip Slack notifications'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   cve-scan:
@@ -241,7 +246,7 @@ jobs:
         continue-on-error: true
 
       - name: Send summary to Slack
-        if: always()
+        if: always() && !inputs.skip_slack
         run: |
           echo "Sending CVE report to Slack..."
           # Use bot token if available (threaded mode), otherwise webhook


### PR DESCRIPTION
## Summary
Add `skip_slack` input to disable Slack notifications during manual testing.

## Changes
- Add `skip_slack` boolean input (default: false)
- Skip Slack step when `skip_slack` is true

## Usage
Manual trigger → set `skip_slack: true` → no notifications sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)