### PR TITLE
feat: add release version to image mirror workflow

### DIFF
--- a/.github/workflows/mirror-external-images-workflow.yaml
+++ b/.github/workflows/mirror-external-images-workflow.yaml
@@ -87,11 +87,15 @@ jobs:
 
     - name: Determine branch context
       id: branch
-      run: |
+      env:
         # Use the branch that triggered the workflow:
         # - workflow_run: use head_branch (the PR branch, e.g., release-2.14)
         # - workflow_dispatch: use ref_name or input branch
-        BRANCH_NAME="${{ github.event.workflow_run.head_branch || inputs.branch || github.ref_name }}"
+        WORKFLOW_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        INPUT_BRANCH: ${{ inputs.branch }}
+        REF_NAME: ${{ github.ref_name }}
+      run: |
+        BRANCH_NAME="${WORKFLOW_RUN_BRANCH:-${INPUT_BRANCH:-${REF_NAME}}}"
         echo "name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
 
         # Extract release version from branch name (e.g., release-2.14 -> 2.14)

--- a/.github/workflows/mirror-external-images-workflow.yaml
+++ b/.github/workflows/mirror-external-images-workflow.yaml
@@ -129,7 +129,26 @@ jobs:
     - name: Authenticate and run mirror script
       id: mirror
       continue-on-error: true
+      env:
+        # Use the branch that triggered the workflow:
+        # - workflow_run: use head_branch (the PR branch, e.g., release-2.14)
+        # - workflow_dispatch: use ref_name or input branch
+        BRANCH_NAME: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref_name }}
       run: |
+        # Extract release version from branch name (e.g., release-2.14 -> 2.14)
+        RELEASE_VERSION=""
+        if [[ "${BRANCH_NAME}" =~ ^release-([0-9]+\.[0-9]+) ]]; then
+          RELEASE_VERSION="${BASH_REMATCH[1]}"
+        fi
+
+        # Add to GitHub Actions summary
+        echo "### Image Mirroring for ACM ${RELEASE_VERSION:-${BRANCH_NAME}}" >> $GITHUB_STEP_SUMMARY
+        echo "**Branch:** ${BRANCH_NAME}" >> $GITHUB_STEP_SUMMARY
+        if [ -n "$RELEASE_VERSION" ]; then
+          echo "**Release Version:** ${RELEASE_VERSION}" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+
         # Authenticate to needed image registries...
 
         # Access to registry.redhat.io needed to resolve external image references (shipped images):
@@ -161,9 +180,18 @@ jobs:
       if: always()
       env:
         EVENT_NAME: ${{ github.event_name }}
-        REF_NAME: ${{ github.ref_name }}
+        # Use the branch that triggered the workflow:
+        # - workflow_run: use head_branch (the PR branch, e.g., release-2.14)
+        # - workflow_dispatch: use ref_name or input branch
+        BRANCH_NAME: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref_name }}
         SLACK_USER_ID: ${{ vars.SLACK_USER_ID }}
       run: |
+        # Extract release version from branch name (e.g., release-2.14 -> 2.14)
+        RELEASE_VERSION=""
+        if [[ "${BRANCH_NAME}" =~ ^release-([0-9]+\.[0-9]+) ]]; then
+          RELEASE_VERSION="${BASH_REMATCH[1]}"
+        fi
+
         # Read results from the JSON file
         if [ ! -f workflow/mirror-results.json ]; then
           echo "No results file found, creating minimal report"
@@ -208,6 +236,12 @@ jobs:
           USER_MENTION=" <@$SLACK_USER_ID>"
         fi
 
+        # Build header with release version if available
+        HEADER_TEXT="Image Mirroring Report"
+        if [ -n "$RELEASE_VERSION" ]; then
+          HEADER_TEXT="Image Mirroring Report - ACM ${RELEASE_VERSION}"
+        fi
+
         # Build the Slack message
         WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         MESSAGE=$(cat <<EOF
@@ -217,7 +251,7 @@ jobs:
               "type": "header",
               "text": {
                 "type": "plain_text",
-                "text": "Image Mirroring Report"
+                "text": "$HEADER_TEXT"
               }
             },
             {
@@ -236,7 +270,7 @@ jobs:
                 },
                 {
                   "type": "mrkdwn",
-                  "text": "*Branch:*\n${REF_NAME}"
+                  "text": "*Branch:*\n${BRANCH_NAME}"
                 }
               ]
             },

--- a/.github/workflows/mirror-external-images-workflow.yaml
+++ b/.github/workflows/mirror-external-images-workflow.yaml
@@ -85,6 +85,25 @@ jobs:
           echo "Manual trigger - branch input: ${INPUT_BRANCH}"
         fi
 
+    - name: Determine branch context
+      id: branch
+      run: |
+        # Use the branch that triggered the workflow:
+        # - workflow_run: use head_branch (the PR branch, e.g., release-2.14)
+        # - workflow_dispatch: use ref_name or input branch
+        BRANCH_NAME="${{ github.event.workflow_run.head_branch || inputs.branch || github.ref_name }}"
+        echo "name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+
+        # Extract release version from branch name (e.g., release-2.14 -> 2.14)
+        RELEASE_VERSION=""
+        if [[ "${BRANCH_NAME}" =~ ^release-([0-9]+\.[0-9]+) ]]; then
+          RELEASE_VERSION="${BASH_REMATCH[1]}"
+        fi
+        echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
+
+        echo "Branch name: ${BRANCH_NAME}"
+        echo "Release version: ${RELEASE_VERSION}"
+
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
@@ -129,17 +148,9 @@ jobs:
     - name: Authenticate and run mirror script
       id: mirror
       continue-on-error: true
-      env:
-        # Use the branch that triggered the workflow:
-        # - workflow_run: use head_branch (the PR branch, e.g., release-2.14)
-        # - workflow_dispatch: use ref_name or input branch
-        BRANCH_NAME: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref_name }}
       run: |
-        # Extract release version from branch name (e.g., release-2.14 -> 2.14)
-        RELEASE_VERSION=""
-        if [[ "${BRANCH_NAME}" =~ ^release-([0-9]+\.[0-9]+) ]]; then
-          RELEASE_VERSION="${BASH_REMATCH[1]}"
-        fi
+        BRANCH_NAME="${{ steps.branch.outputs.name }}"
+        RELEASE_VERSION="${{ steps.branch.outputs.release_version }}"
 
         # Add to GitHub Actions summary
         echo "### Image Mirroring for ACM ${RELEASE_VERSION:-${BRANCH_NAME}}" >> $GITHUB_STEP_SUMMARY
@@ -180,17 +191,10 @@ jobs:
       if: always()
       env:
         EVENT_NAME: ${{ github.event_name }}
-        # Use the branch that triggered the workflow:
-        # - workflow_run: use head_branch (the PR branch, e.g., release-2.14)
-        # - workflow_dispatch: use ref_name or input branch
-        BRANCH_NAME: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref_name }}
         SLACK_USER_ID: ${{ vars.SLACK_USER_ID }}
       run: |
-        # Extract release version from branch name (e.g., release-2.14 -> 2.14)
-        RELEASE_VERSION=""
-        if [[ "${BRANCH_NAME}" =~ ^release-([0-9]+\.[0-9]+) ]]; then
-          RELEASE_VERSION="${BASH_REMATCH[1]}"
-        fi
+        BRANCH_NAME="${{ steps.branch.outputs.name }}"
+        RELEASE_VERSION="${{ steps.branch.outputs.release_version }}"
 
         # Read results from the JSON file
         if [ ! -f workflow/mirror-results.json ]; then

--- a/.github/workflows/mirror-external-images-workflow.yaml
+++ b/.github/workflows/mirror-external-images-workflow.yaml
@@ -242,55 +242,59 @@ jobs:
           HEADER_TEXT="Image Mirroring Report - ACM ${RELEASE_VERSION}"
         fi
 
-        # Build the Slack message
+        # Build the Slack message using jq for safe JSON construction
         WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-        MESSAGE=$(cat <<EOF
-        {
-          "blocks": [
-            {
-              "type": "header",
-              "text": {
-                "type": "plain_text",
-                "text": "$HEADER_TEXT"
-              }
-            },
-            {
-              "type": "section",
-              "text": {
-                "type": "mrkdwn",
-                "text": "$STATUS$USER_MENTION\n\n$SUMMARY$DETAILS"
-              }
-            },
-            {
-              "type": "section",
-              "fields": [
-                {
-                  "type": "mrkdwn",
-                  "text": "*Triggered by:*\n${EVENT_NAME}"
-                },
-                {
-                  "type": "mrkdwn",
-                  "text": "*Branch:*\n${BRANCH_NAME}"
+        MESSAGE=$(jq -n \
+          --arg header "$HEADER_TEXT" \
+          --arg status "$STATUS$USER_MENTION" \
+          --arg summary "$SUMMARY$DETAILS" \
+          --arg event "$EVENT_NAME" \
+          --arg branch "$BRANCH_NAME" \
+          --arg url "$WORKFLOW_URL" \
+          '{
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": $header
                 }
-              ]
-            },
-            {
-              "type": "actions",
-              "elements": [
-                {
-                  "type": "button",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "View Workflow Run"
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ($status + "\n\n" + $summary)
+                }
+              },
+              {
+                "type": "section",
+                "fields": [
+                  {
+                    "type": "mrkdwn",
+                    "text": ("*Triggered by:*\n" + $event)
                   },
-                  "url": "$WORKFLOW_URL"
-                }
-              ]
-            }
-          ]
-        }
-        EOF
-        )
+                  {
+                    "type": "mrkdwn",
+                    "text": ("*Branch:*\n" + $branch)
+                  }
+                ]
+              },
+              {
+                "type": "actions",
+                "elements": [
+                  {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View Workflow Run"
+                    },
+                    "url": $url
+                  }
+                ]
+              }
+            ]
+          }')
 
         # Send to Slack
         curl -X POST -H 'Content-type: application/json' \


### PR DESCRIPTION
## Summary
Extract and display release version in image mirroring workflow output for better visibility.

## Changes
- Extract release version from branch name (e.g., `release-2.14` → `2.14`)
- Add version to Slack notification header: "Image Mirroring Report - ACM 2.14"
- Add version to GitHub Actions summary output
- Fix branch name detection to use triggering branch (`github.event.workflow_run.head_branch`) instead of workflow file location (`github.ref_name`)

## Problem
When workflow triggered by `workflow_run`, `github.ref_name` always returns `main` (where workflow file lives), not actual release branch being mirrored. This made Slack notifications unhelpful - couldn't tell which release was being mirrored.

## Solution
Use `github.event.workflow_run.head_branch` for workflow_run triggers to get actual PR branch name.

## Test Plan
- [ ] Trigger mirror workflow from release branch
- [ ] Verify Slack shows "Image Mirroring Report - ACM X.Y"
- [ ] Verify GitHub Actions summary shows release version
- [ ] Verify non-release branches still work (no version shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced GitHub Actions step summaries with branch and release version information
  * Improved Slack notifications with more descriptive branch and release details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->