### PR TITLE
fix: Slack newlines and broader version regex

### DIFF
--- a/.github/workflows/mirror-external-images-workflow.yaml
+++ b/.github/workflows/mirror-external-images-workflow.yaml
@@ -1,5 +1,7 @@
 name: Mirror External Images
 
+run-name: "Mirror Images - ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref_name }}"
+
 # SECURITY NOTES:
 # 1. This workflow handles sensitive secrets (registry credentials, private keys)
 # 2. Command injection mitigations:

--- a/.github/workflows/mirror-external-images-workflow.yaml
+++ b/.github/workflows/mirror-external-images-workflow.yaml
@@ -98,9 +98,10 @@ jobs:
         BRANCH_NAME="${WORKFLOW_RUN_BRANCH:-${INPUT_BRANCH:-${REF_NAME}}}"
         echo "name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
 
-        # Extract release version from branch name (e.g., release-2.14 -> 2.14)
+        # Extract release version from branch name
+        # Matches: release-2.14, update-snapshot-release-5.0, etc.
         RELEASE_VERSION=""
-        if [[ "${BRANCH_NAME}" =~ ^release-([0-9]+\.[0-9]+) ]]; then
+        if [[ "${BRANCH_NAME}" =~ release-([0-9]+\.[0-9]+) ]]; then
           RELEASE_VERSION="${BASH_REMATCH[1]}"
         fi
         echo "release_version=${RELEASE_VERSION}" >> $GITHUB_OUTPUT
@@ -226,15 +227,10 @@ jobs:
             HAS_FAILURE=false
           fi
 
-          # Build summary
-          SUMMARY="*Summary:*\n• Mirrored: $MIRRORED\n• Skipped: $SKIPPED\n• Failed: $FAILED"
-
-          # Build failure details if any
-          DETAILS=""
+          # Get failure details if any
+          FAILURES_JSON=""
           if [ "$FAILED" -gt 0 ]; then
-            DETAILS="\n\n*Failed Images:*\n"
-            FAILURES=$(jq -r '.failures[] | "• `\(.image_key)` [\(.operator)]\n  Source: `\(.source)`\n  Target: `\(.target)`\n  Error: \(.error)\n"' workflow/mirror-results.json)
-            DETAILS="$DETAILS$FAILURES"
+            FAILURES_JSON=$(jq -c '[.failures[] | "• `\(.image_key)` [\(.operator)]\n  Source: `\(.source)`\n  Target: `\(.target)`\n  Error: \(.error)"]' workflow/mirror-results.json)
           fi
         fi
 
@@ -255,7 +251,10 @@ jobs:
         MESSAGE=$(jq -n \
           --arg header "$HEADER_TEXT" \
           --arg status "$STATUS$USER_MENTION" \
-          --arg summary "$SUMMARY$DETAILS" \
+          --argjson mirrored "$MIRRORED" \
+          --argjson skipped "$SKIPPED" \
+          --argjson failed "$FAILED" \
+          --argjson failures "${FAILURES_JSON:-[]}" \
           --arg event "$EVENT_NAME" \
           --arg branch "$BRANCH_NAME" \
           --arg url "$WORKFLOW_URL" \
@@ -272,7 +271,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": ($status + "\n\n" + $summary)
+                  "text": ($status + "\n\n*Summary:*\n• Mirrored: " + ($mirrored|tostring) + "\n• Skipped: " + ($skipped|tostring) + "\n• Failed: " + ($failed|tostring) + (if ($failures | length) > 0 then "\n\n*Failed Images:*\n" + ($failures | join("\n")) else "" end))
                 }
               },
               {


### PR DESCRIPTION
## Summary
Fix literal `\n` in Slack messages and extract version from broader branch name patterns.

## Changes
- Build summary text in jq instead of bash to properly render newlines
- Change regex from `^release-` to `release-` to match branches like `update-snapshot-release-5.0`

## Problem
1. Slack showed literal `\n` instead of newlines (e.g., "*Summary:*\n• Mirrored: 3")
2. Version extraction failed for branches like `update-snapshot-release-5.0` (only matched `release-X.Y`)

## Solution
1. Use `--argjson` + build text in jq instead of bash `\n` + `--arg`
2. Remove `^` anchor from regex to match version anywhere in branch name

## Test Plan
- [x] Tested on `update-snapshot-release-5.0` branch - extracts `5.0`
- [ ] Verify Slack renders newlines correctly
- [ ] Verify `release-2.14` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)