### PR TITLE
chore: readjust snapshot generation schedules based on release activity

### DIFF
--- a/.github/workflows/gen-latest-snapshot-acm-211.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-211.yaml
@@ -3,7 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.11
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 13 * * 1'  # 9:00AM ET Mondays (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 17 * * 4'  # 1:00PM ET Thursdays (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-211.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-211.yaml
@@ -3,7 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.11
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 13 * * 2,4'  # 9:00AM ET Tuesdays and Thursdays (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 13 * * 1'  # 9:00AM ET Mondays (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-211.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-211.yaml
@@ -3,7 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.11
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 13 * * *'  # 9:00AM EST every day (UTC-4)
+    - cron: '0 13 * * 2,4'  # 9:00AM ET Tuesdays and Thursdays (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-212.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-212.yaml
@@ -2,9 +2,6 @@ name: Gen Latest Dev Snapshot - ACM 2.12
 
 on:
   workflow_dispatch: {}
-  schedule:
-    - cron: '0 8 * * *'   # 4:00AM EST every day (UTC-4)
-    - cron: '0 20 * * *'  # 4:00PM EST every day (UTC-4)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-213.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-213.yaml
@@ -3,7 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.13
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 7 * * 1,3'   # 3:00AM ET Mondays and Wednesdays (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 19 * * 2,4'   # 3:00PM ET Tuesdays and Thursdays (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-213.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-213.yaml
@@ -3,8 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.13
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 7 * * *'   # 3:00AM EST every day (UTC-4)
-    - cron: '0 19 * * *'  # 3:00PM EST every day (UTC-4)
+    - cron: '0 7 * * *'   # 3:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-213.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-213.yaml
@@ -3,7 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.13
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 7 * * *'   # 3:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 7 * * 1,3'   # 3:00AM ET Mondays and Wednesdays (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-214.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-214.yaml
@@ -3,7 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.14
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 6 * * 1,3,5'   # 2:00AM ET Mon/Wed/Fri (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 19 * * 1,3,5'   # 3:00PM ET Mon/Wed/Fri (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-214.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-214.yaml
@@ -3,7 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.14
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 6 * * *'   # 2:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 6 * * 1,3,5'   # 2:00AM ET Mon/Wed/Fri (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-214.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-214.yaml
@@ -3,9 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.14
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 6 * * *'   # 2:00AM EST every day (UTC-4)
-    - cron: '0 14 * * *'  # 10:00AM EST every day (UTC-4)
-    - cron: '0 0 * * *'   # 8:00PM EST every day (UTC-4)
+    - cron: '0 6 * * *'   # 2:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-215.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-215.yaml
@@ -3,10 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.15
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 5 * * *'   # 1:00AM EST every day (UTC-4)
-    - cron: '0 11 * * *'  # 7:00AM EST every day (UTC-4)
-    - cron: '0 17 * * *'  # 1:00PM EST every day (UTC-4)
-    - cron: '0 23 * * *'  # 7:00PM EST every day (UTC-4)
+    - cron: '0 5 * * *'   # 1:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-215.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-215.yaml
@@ -3,7 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.15
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 5 * * 1,3,5'   # 1:00AM ET Mon/Wed/Fri (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 17 * * 1,3,5'   # 1:00PM ET Mon/Wed/Fri (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-215.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-215.yaml
@@ -3,7 +3,7 @@ name: Gen Latest Dev Snapshot - ACM 2.15
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 5 * * *'   # 1:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 5 * * 1,3,5'   # 1:00AM ET Mon/Wed/Fri (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-216.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-216.yaml
@@ -3,10 +3,8 @@ name: Gen Latest Dev Snapshot - ACM 2.16
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 4 * * *'   # 12:00AM EST every day (UTC-4)
-    - cron: '0 10 * * *'  # 6:00AM EST every day (UTC-4)
-    - cron: '0 16 * * *'  # 12:00PM EST every day (UTC-4)
-    - cron: '0 22 * * *'  # 6:00PM EST every day (UTC-4)
+    - cron: '0 13 * * *'  # 9:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 18 * * *'  # 2:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-217.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-217.yaml
@@ -3,10 +3,8 @@ name: Gen Latest Dev Snapshot - ACM 2.17
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 3 * * *'   # 11:00PM EST every day (UTC-4)
-    - cron: '0 9 * * *'   # 5:00AM EST every day (UTC-4)
-    - cron: '0 15 * * *'  # 11:00AM EST every day (UTC-4)
-    - cron: '0 21 * * *'  # 5:00PM EST every day (UTC-4)
+    - cron: '0 14 * * *'  # 10:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 20 * * *'  # 4:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
 
 jobs:
   snapshot:

--- a/.github/workflows/gen-latest-snapshot-acm-50.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-50.yaml
@@ -3,8 +3,9 @@ name: Gen Latest Dev Snapshot - ACM 5.0
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 2 * * *'   # 10:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
-    - cron: '0 12 * * *'  # 8:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 6 * * *'   # 2:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 14 * * *'  # 10:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 22 * * *'  # 6:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
 
 permissions:
   contents: read

--- a/.github/workflows/gen-latest-snapshot-acm-50.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-50.yaml
@@ -3,9 +3,9 @@ name: Gen Latest Dev Snapshot - ACM 5.0
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 6 * * *'   # 2:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
-    - cron: '0 14 * * *'  # 10:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
-    - cron: '0 22 * * *'  # 6:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 12 * * *'  # 8:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 16 * * *'  # 12:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 21 * * *'  # 5:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
 
 permissions:
   contents: read

--- a/.github/workflows/gen-latest-snapshot-acm-51.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-51.yaml
@@ -3,7 +3,8 @@ name: Gen Latest Dev Snapshot - ACM 5.1
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 1 * * 2,4'   # 9:00PM ET Tuesdays and Thursdays (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 1 * * *'   # 9:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 13 * * *'  # 9:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
 
 permissions:
   contents: read

--- a/.github/workflows/gen-latest-snapshot-acm-51.yaml
+++ b/.github/workflows/gen-latest-snapshot-acm-51.yaml
@@ -3,8 +3,8 @@ name: Gen Latest Dev Snapshot - ACM 5.1
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: '0 1 * * *'   # 9:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
-    - cron: '0 13 * * *'  # 9:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 15 * * *'  # 11:00AM ET every day (UTC-4 during DST / UTC-5 otherwise)
+    - cron: '0 22 * * *'  # 6:00PM ET every day (UTC-4 during DST / UTC-5 otherwise)
 
 permissions:
   contents: read


### PR DESCRIPTION
# Description

Readjust dev snapshot generation schedules to match current release activity levels. All builds now run during work hours (8 AM - 6 PM ET) with at least 1 hour separation. 5.0 is the active dev sprint and gets the most frequent snapshots.

## Related Issue

N/A

## Changes Made

| Version | Before | After | Rationale |
|---------|--------|-------|-----------|
| **2.11** | Daily 9 AM | Thu 1 PM | Oldest supported, minimal activity |
| **2.12** | 2x daily (4 AM, 4 PM) | Manual only (workflow_dispatch) | EOL |
| **2.13** | 2x daily (3 AM, 3 PM) | Tue/Thu 3 PM | Maintenance release |
| **2.14** | 3x daily (2 AM, 10 AM, 8 PM) | MWF 3 PM | Maintenance release |
| **2.15** | 4x daily (1 AM, 7 AM, 1 PM, 7 PM) | MWF 1 PM | Maintenance release |
| **2.16** | 4x daily (12 AM, 6 AM, 12 PM, 6 PM) | 2x daily (9 AM, 2 PM) | Recent release |
| **2.17** | 4x daily (11 PM, 5 AM, 11 AM, 5 PM) | 2x daily (10 AM, 4 PM) | Recent release |
| **5.0** | 2x daily (10 PM, 8 AM) | **3x daily (8 AM, 12 PM, 5 PM)** | **Current dev sprint** |
| **5.1** | Tue/Thu only (9 PM) | 2x daily (11 AM, 6 PM) | Next sprint |

### Full Schedule (all times ET)

```
┌──────────┬─────────┬─────────┬─────────┬─────────┬─────────┐
│ Time     │ Mon     │ Tue     │ Wed     │ Thu     │ Fri     │
├──────────┼─────────┼─────────┼─────────┼─────────┼─────────┤
│  8:00 AM │ 5.0     │ 5.0     │ 5.0     │ 5.0     │ 5.0     │
│  9:00 AM │ 2.16    │ 2.16    │ 2.16    │ 2.16    │ 2.16    │
│ 10:00 AM │ 2.17    │ 2.17    │ 2.17    │ 2.17    │ 2.17    │
│ 11:00 AM │ 5.1     │ 5.1     │ 5.1     │ 5.1     │ 5.1     │
│ 12:00 PM │ 5.0     │ 5.0     │ 5.0     │ 5.0     │ 5.0     │
│  1:00 PM │ 2.15    │   —     │ 2.15    │ 2.11    │ 2.15    │
│  2:00 PM │ 2.16    │ 2.16    │ 2.16    │ 2.16    │ 2.16    │
│  3:00 PM │ 2.14    │ 2.13    │ 2.14    │ 2.13    │ 2.14    │
│  4:00 PM │ 2.17    │ 2.17    │ 2.17    │ 2.17    │ 2.17    │
│  5:00 PM │ 5.0     │ 5.0     │ 5.0     │ 5.0     │ 5.0     │
│  6:00 PM │ 5.1     │ 5.1     │ 5.1     │ 5.1     │ 5.1     │
└──────────┴─────────┴─────────┴─────────┴─────────┴─────────┘
```

## Checklist

- [x] I have tested the changes locally and they are functioning as expected.
- [x] I have updated the documentation (if necessary) to reflect the changes.
- [x] I have ensured that my code follows the project's coding standards.
- [x] I have checked for any potential security issues and addressed them.
- [x] I have rebased my branch on top of the latest main/master branch.

## Additional Notes

Cron expressions verified against UTC offsets. All times are ET (UTC-4 during DST / UTC-5 otherwise). MCE operator-bundle has a matching PR with the same schedule.

## Reviewers

/cc @dislbenn

## Definition of Done

- [ ] Code is reviewed.
- [ ] Code is tested.
- [ ] Documentation is updated.
- [ ] All checks and tests pass.
- [ ] Approved by at least one reviewer.
- [ ] Merged into the main/master branch.