### PR TITLE
fix: add retry logic to git fetch for transient network failures

### DIFF
--- a/tools/run-script-from-tools-repo
+++ b/tools/run-script-from-tools-repo
@@ -120,8 +120,19 @@ if [[ ! -d "$tools_repo_clone_dir" ]]; then
    basic_auth_encoded=$(echo -n "$basic_auth_creds" | base64)
    git config  "http.https://github.com/.extraheader" "Authorization: basic $basic_auth_encoded"
 
-   git fetch --depth 1 origin "$tools_repo_branch"
-   git_fetch_rc=$?
+   max_attempts=3
+   git_fetch_rc=1
+   for attempt in $(seq 1 $max_attempts); do
+      git fetch --depth 1 origin "$tools_repo_branch"
+      git_fetch_rc=$?
+      if [[ $git_fetch_rc -eq 0 ]]; then
+         break
+      fi
+      if [[ $attempt -lt $max_attempts ]]; then
+         echo "WARNING: git fetch attempt $attempt of $max_attempts failed (rc=$git_fetch_rc). Retrying in ${attempt}0s..."
+         sleep "${attempt}0"
+      fi
+   done
 
    # In case we're run locally, be friendly and restore original Git SSH command
    if [[ -n "$save_git_ssh_cmd" ]]; then
@@ -130,7 +141,7 @@ if [[ ! -d "$tools_repo_clone_dir" ]]; then
       git config --global --unset core.sshCommand
    fi
    if [[ $git_fetch_rc -ne 0 ]]; then
-      echo "ERROR: Could not fetch tools repo."
+      echo "ERROR: Could not fetch tools repo after $max_attempts attempts."
       exit 2
   fi
 


### PR DESCRIPTION
## Summary
- `git fetch` of the tools repo (`stolostron/release`) fails intermittently with `Failed sending HTTP request` on GitHub Actions runners
- This has been causing a ~15-25% daily failure rate since late May 2026, affecting both `acm-operator-bundle` and `mce-operator-bundle`
- The failure is at the TCP/TLS level (50ms between `git init` and fatal — too fast for a full roundtrip), so credential fixes don't help
- Adds retry loop (3 attempts) with linear backoff (10s, 20s) around `git fetch` to absorb transient failures

## Test plan
- [ ] Verify retry logic by reviewing the script change
- [ ] Monitor `Gen Bundle Contents When Triggered` workflow runs for reduced failure rate after merge
- [ ] Mirror PR also opened on `mce-operator-bundle`: https://github.com/stolostron/mce-operator-bundle/pull/4377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when fetching the tools repository by automatically retrying temporary failures.
  * Added progressively longer wait times between attempts and clearer warnings during retries.
  * Enhanced final error messages to indicate the total number of attempts made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->