### PR TITLE
fix: update stale auth comment to match credential.helper implementation

### DIFF
--- a/tools/run-script-from-tools-repo
+++ b/tools/run-script-from-tools-repo
@@ -111,8 +111,8 @@ if [[ ! -d "$tools_repo_clone_dir" ]]; then
    git init
 
    # Rather than clone with an https URL that includes the token, instead clone
-   # generically and configure the git client to add an Authentication header that
-   # specifies the encoded "token:<TOKEN_VALUE>" auth info.
+   # generically and configure the git credential helper to provide the token
+   # as the password for authentication.
 
    git remote add origin "https://github.com/$tools_repo"
    git config credential.helper '!f() { echo "username=x-access-token"; echo "password='"$tools_repo_access_token"'"; }; f'


### PR DESCRIPTION
## Summary
- Updates stale comment in `tools/run-script-from-tools-repo` that still referenced the old Authentication header approach, which was replaced by `credential.helper` in PR #4197.

## Test plan
- [ ] Verify comment-only change — no functional impact
- [ ] Confirm comment accurately describes `credential.helper` usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Git credential configuration guidance to clarify that the credential helper supplies the token as the authentication password.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->